### PR TITLE
Finalize auth and add error pages

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -13,6 +13,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
 use Laravel\Fortify\Fortify;
+use Inertia\Inertia;
 
 class FortifyServiceProvider extends ServiceProvider
 {
@@ -29,6 +30,15 @@ class FortifyServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        Fortify::loginView(fn() => Inertia::render('Auth/Login'));
+        Fortify::registerView(fn() => Inertia::render('Auth/Register'));
+        Fortify::requestPasswordResetLinkView(fn() => Inertia::render('Auth/ForgotPassword'));
+        Fortify::resetPasswordView(fn($request) => Inertia::render('Auth/ResetPassword', [
+            'token' => $request->route('token'),
+            'email' => $request->email,
+        ]));
+        Fortify::verifyEmailView(fn() => Inertia::render('Auth/VerifyEmail'));
+
         Fortify::createUsersUsing(CreateNewUser::class);
         Fortify::updateUserProfileInformationUsing(UpdateUserProfileInformation::class);
         Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -146,7 +146,7 @@ return [
     'features' => [
         Features::registration(),
         Features::resetPasswords(),
-        // Features::emailVerification(),
+        Features::emailVerification(),
         Features::updateProfileInformation(),
         Features::updatePasswords(),
         Features::twoFactorAuthentication([

--- a/resources/js/Pages/Auth/ForgotPassword.jsx
+++ b/resources/js/Pages/Auth/ForgotPassword.jsx
@@ -1,0 +1,38 @@
+import { Head, useForm } from '@inertiajs/react';
+import { Box, Button, Input, Text, VStack } from '@chakra-ui/react';
+
+export default function ForgotPassword({ status }) {
+  const { data, setData, post, processing, errors } = useForm({
+    email: ''
+  });
+
+  const submit = e => {
+    e.preventDefault();
+    post(route('password.email'));
+  };
+
+  return (
+    <> 
+      <Head title="Mot de passe oublié" />
+      <Box maxW="md" mx="auto" mt={10} p={6} bg="white" borderRadius="md" boxShadow="md">
+        <form onSubmit={submit}>
+          <VStack spacing={4} align="stretch">
+            <Text fontSize="sm" color="gray.600">
+              Mot de passe oublié ? Indiquez votre email et nous vous enverrons un lien pour le réinitialiser.
+            </Text>
+            {status && <Text color="green.600">{status}</Text>}
+            <Input
+              type="email"
+              value={data.email}
+              onChange={e => setData('email', e.target.value)}
+              placeholder="Adresse email"
+              isInvalid={Boolean(errors.email)}
+            />
+            {errors.email && <Text color="red.500">{errors.email}</Text>}
+            <Button colorScheme="orange" type="submit" isLoading={processing}>Envoyer le lien</Button>
+          </VStack>
+        </form>
+      </Box>
+    </>
+  );
+}

--- a/resources/js/Pages/Auth/ResetPassword.jsx
+++ b/resources/js/Pages/Auth/ResetPassword.jsx
@@ -1,0 +1,52 @@
+import { Head, useForm } from '@inertiajs/react';
+import { Box, Button, Input, Text, VStack } from '@chakra-ui/react';
+
+export default function ResetPassword({ token, email }) {
+  const { data, setData, post, processing, errors } = useForm({
+    token,
+    email: email || '',
+    password: '',
+    password_confirmation: ''
+  });
+
+  const submit = e => {
+    e.preventDefault();
+    post(route('password.update'));
+  };
+
+  return (
+    <> 
+      <Head title="Réinitialiser le mot de passe" />
+      <Box maxW="md" mx="auto" mt={10} p={6} bg="white" borderRadius="md" boxShadow="md">
+        <form onSubmit={submit}>
+          <VStack spacing={4} align="stretch">
+            <Input
+              type="email"
+              value={data.email}
+              onChange={e => setData('email', e.target.value)}
+              placeholder="Adresse email"
+              isInvalid={Boolean(errors.email)}
+            />
+            {errors.email && <Text color="red.500">{errors.email}</Text>}
+            <Input
+              type="password"
+              value={data.password}
+              onChange={e => setData('password', e.target.value)}
+              placeholder="Nouveau mot de passe"
+              isInvalid={Boolean(errors.password)}
+            />
+            <Input
+              type="password"
+              value={data.password_confirmation}
+              onChange={e => setData('password_confirmation', e.target.value)}
+              placeholder="Confirmer le mot de passe"
+              isInvalid={Boolean(errors.password_confirmation)}
+            />
+            {errors.password && <Text color="red.500">{errors.password}</Text>}
+            <Button colorScheme="orange" type="submit" isLoading={processing}>Réinitialiser</Button>
+          </VStack>
+        </form>
+      </Box>
+    </>
+  );
+}

--- a/resources/js/Pages/Auth/VerifyEmail.jsx
+++ b/resources/js/Pages/Auth/VerifyEmail.jsx
@@ -1,0 +1,33 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+import { Box, Button, Text, VStack, HStack } from '@chakra-ui/react';
+
+export default function VerifyEmail({ status }) {
+  const { post, processing } = useForm({});
+
+  const submit = e => {
+    e.preventDefault();
+    post(route('verification.send'));
+  };
+
+  return (
+    <> 
+      <Head title="Vérification de l'email" />
+      <Box maxW="md" mx="auto" mt={10} p={6} bg="white" borderRadius="md" boxShadow="md" textAlign="center">
+        <VStack spacing={4}>
+          <Text fontSize="sm" color="gray.600">
+            Avant de continuer, veuillez vérifier votre adresse email en cliquant sur le lien que nous venons de vous envoyer.
+            Si vous ne l'avez pas reçu, nous pouvons vous en envoyer un autre.
+          </Text>
+          {status === 'verification-link-sent' && (
+            <Text color="green.600">Un nouveau lien de vérification a été envoyé à votre adresse email.</Text>
+          )}
+          <HStack spacing={4} justify="center" as="form" onSubmit={submit}>
+            <Button colorScheme="orange" type="submit" isLoading={processing}>Renvoyer l'email</Button>
+            <Link href={route('profile.show')}><Button variant="link" colorScheme="orange">Profil</Button></Link>
+            <Link href={route('logout')} method="post" as="button"><Button variant="link" colorScheme="orange">Déconnexion</Button></Link>
+          </HStack>
+        </VStack>
+      </Box>
+    </>
+  );
+}

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,0 +1,12 @@
+@extends('errors.error-layout')
+
+@section('title', 'Accès refusé')
+@section('code', '403')
+@section('message', "Désolé, vous n'avez pas accès à cette page.")
+
+@section('image')
+<svg xmlns="http://www.w3.org/2000/svg" class="mx-auto w-52 h-52 text-orange-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+  <rect x="3" y="11" width="18" height="10" rx="2"/>
+  <path d="M7 11V7a5 5 0 0110 0v4"/>
+</svg>
+@endsection

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,12 @@
+@extends('errors.error-layout')
+
+@section('title', 'Page non trouvée')
+@section('code', '404')
+@section('message', 'La page demandée est introuvable.')
+
+@section('image')
+<svg xmlns="http://www.w3.org/2000/svg" class="mx-auto w-52 h-52 text-orange-500 animate-bounce" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+  <circle cx="11" cy="11" r="8" />
+  <path d="M21 21l-4.35-4.35" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+@endsection

--- a/resources/views/errors/501.blade.php
+++ b/resources/views/errors/501.blade.php
@@ -1,0 +1,11 @@
+@extends('errors.error-layout')
+
+@section('title', 'Non implémenté')
+@section('code', '501')
+@section('message', "Cette fonctionnalité n'est pas encore disponible.")
+
+@section('image')
+<svg xmlns="http://www.w3.org/2000/svg" class="mx-auto w-52 h-52 text-orange-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v3m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+</svg>
+@endsection

--- a/resources/views/errors/error-layout.blade.php
+++ b/resources/views/errors/error-layout.blade.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_','-',app()->getLocale()) }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@yield('code') - @yield('title')</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-50 flex items-center justify-center min-h-screen px-4">
+    <div class="text-center">
+        @yield('image')
+        <h1 class="text-6xl font-bold text-orange-500 mt-6">@yield('code')</h1>
+        <p class="mt-4 text-gray-600">@yield('message')</p>
+        <a href="{{ url('/') }}" class="mt-6 inline-block px-6 py-3 bg-orange-500 text-white rounded hover:bg-orange-600">Accueil</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enable email verification in Fortify
- register React pages for Fortify views
- add React pages for forgot/reset password and email verification
- create custom error pages with basic Tailwind styling

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686457a43f1083309da86d6b6832d8b6