### PR TITLE
Improve search filters and favorites

### DIFF
--- a/app/Http/Controllers/ListingController.php
+++ b/app/Http/Controllers/ListingController.php
@@ -13,63 +13,10 @@ class ListingController extends Controller
 {
     public function index(Request $request)
     {
-        $query = Listing::query()->with('category', 'user')->where('status', 'active');
-
-        if ($request->filled('city')) {
-            $query->where('city', $request->city);
-        }
-
-        if ($request->filled('postal_code')) {
-            $query->where('postal_code', $request->postal_code);
-        }
-
-        if ($request->filled('min_price')) {
-            $query->where('price', '>=', $request->min_price);
-        }
-
-        if ($request->filled('max_price')) {
-            $query->where('price', '<=', $request->max_price);
-        }
-
-        if ($request->filled('min_surface')) {
-            $query->where('surface', '>=', $request->min_surface);
-        }
-
-        if ($request->filled('max_surface')) {
-            $query->where('surface', '<=', $request->max_surface);
-        }
-
-        if ($request->filled('rooms')) {
-            $query->where('rooms', '>=', $request->rooms);
-        }
-
-        if ($request->filled('bedrooms')) {
-            $query->where('bedrooms', '>=', $request->bedrooms);
-        }
-
-        if ($request->filled('has_terrace')) {
-            $query->where('has_terrace', (bool) $request->has_terrace);
-        }
-
-        if ($request->filled('has_parking')) {
-            $query->where('has_parking', (bool) $request->has_parking);
-        }
-
-        if ($request->filled('category_id')) {
-            $query->where('category_id', $request->category_id);
-        }
-
-        if ($request->filled('lat') && $request->filled('lng')) {
-            $lat = $request->lat;
-            $lng = $request->lng;
-            $radius = $request->radius ?? 10;
-
-            $haversine = "(6371 * acos(cos(radians($lat)) * cos(radians(latitude)) * cos(radians(longitude) - radians($lng)) + sin(radians($lat)) * sin(radians(latitude))))";
-
-            $query->selectRaw("*, $haversine AS distance")
-                ->having("distance", "<=", $radius)
-                ->orderBy("distance");
-        }
+        $query = Listing::query()
+            ->with('category', 'user')
+            ->where('status', 'active')
+            ->filter($request->all());
 
 
         $listings = $query->paginate(10);

--- a/app/Models/Listing.php
+++ b/app/Models/Listing.php
@@ -57,6 +57,67 @@ class Listing extends Model
     public function gallery() {
         return $this->morphMany(File::class, 'fileable')->where('type', 'image');
     }
+
+    public function scopeFilter($query, array $filters)
+    {
+        if (!empty($filters['city'])) {
+            $query->where('city', $filters['city']);
+        }
+
+        if (!empty($filters['postal_code'])) {
+            $query->where('postal_code', $filters['postal_code']);
+        }
+
+        if (!empty($filters['min_price'])) {
+            $query->where('price', '>=', $filters['min_price']);
+        }
+
+        if (!empty($filters['max_price'])) {
+            $query->where('price', '<=', $filters['max_price']);
+        }
+
+        if (!empty($filters['min_surface'])) {
+            $query->where('surface', '>=', $filters['min_surface']);
+        }
+
+        if (!empty($filters['max_surface'])) {
+            $query->where('surface', '<=', $filters['max_surface']);
+        }
+
+        if (!empty($filters['rooms'])) {
+            $query->where('rooms', '>=', $filters['rooms']);
+        }
+
+        if (!empty($filters['bedrooms'])) {
+            $query->where('bedrooms', '>=', $filters['bedrooms']);
+        }
+
+        if (array_key_exists('has_terrace', $filters)) {
+            $query->where('has_terrace', (bool) $filters['has_terrace']);
+        }
+
+        if (array_key_exists('has_parking', $filters)) {
+            $query->where('has_parking', (bool) $filters['has_parking']);
+        }
+
+        if (!empty($filters['category_id'])) {
+            $query->where('category_id', $filters['category_id']);
+        }
+
+        if (!empty($filters['lat']) && !empty($filters['lng'])) {
+            $lat = $filters['lat'];
+            $lng = $filters['lng'];
+            $radius = $filters['radius'] ?? 10;
+
+            $haversine = "(6371 * acos(cos(radians($lat)) * cos(radians(latitude)) * cos(radians(longitude) - radians($lng)) + sin(radians($lat)) * sin(radians(latitude))))";
+
+            $query->selectRaw("*, $haversine AS distance")
+                ->having("distance", "<=", $radius)
+                ->orderBy("distance");
+        }
+
+        return $query;
+    }
     public function favoredBy()
     {
         return $this->belongsToMany(User::class, 'favorites')->withTimestamps();
@@ -64,3 +125,4 @@ class Listing extends Model
 
 
 }
+

--- a/resources/js/Components/Listing/FilterSidebar.jsx
+++ b/resources/js/Components/Listing/FilterSidebar.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import {
+  Box,
+  VStack,
+  Text,
+  RangeSlider,
+  RangeSliderTrack,
+  RangeSliderFilledTrack,
+  RangeSliderThumb,
+  Flex,
+  HStack,
+  Checkbox,
+  IconButton,
+  Divider,
+  Button
+} from '@chakra-ui/react';
+import { FaMinus, FaPlus } from 'react-icons/fa';
+
+export default function FilterSidebar({ searchParams, setSearchParams, onSearch }) {
+  const handleSliderChange = (type, val) => {
+    if (type === 'price') {
+      setSearchParams(prev => ({ ...prev, min_price: val[0], max_price: val[1] }));
+    } else if (type === 'surface') {
+      setSearchParams(prev => ({ ...prev, min_surface: val[0], max_surface: val[1] }));
+    }
+  };
+
+  const handleCheckboxChange = e => {
+    const { name, checked } = e.target;
+    setSearchParams(prev => ({ ...prev, [name]: checked }));
+  };
+
+  const increment = field => {
+    setSearchParams(prev => ({ ...prev, [field]: (prev[field] || 0) + 1 }));
+  };
+
+  const decrement = field => {
+    setSearchParams(prev => ({ ...prev, [field]: Math.max((prev[field] || 0) - 1, 0) }));
+  };
+
+  return (
+    <VStack align="stretch" spacing={4} position="sticky" top="100px">
+      <Box>
+        <Text mb={2}>Prix (€)</Text>
+        <RangeSlider
+          aria-label={['min', 'max']}
+          defaultValue={[searchParams.min_price || 0, searchParams.max_price || 1000000]}
+          min={0}
+          max={1000000}
+          step={10000}
+          onChangeEnd={val => handleSliderChange('price', val)}
+        >
+          <RangeSliderTrack>
+            <RangeSliderFilledTrack />
+          </RangeSliderTrack>
+          <RangeSliderThumb index={0} />
+          <RangeSliderThumb index={1} />
+        </RangeSlider>
+        <Flex justify="space-between" mt={1}>
+          <Text>{searchParams.min_price ?? 0} €</Text>
+          <Text>{searchParams.max_price ?? 1000000} €</Text>
+        </Flex>
+      </Box>
+
+      <Box>
+        <Text mb={2}>Surface (m²)</Text>
+        <RangeSlider
+          aria-label={['min', 'max']}
+          defaultValue={[searchParams.min_surface || 0, searchParams.max_surface || 500]}
+          min={0}
+          max={500}
+          step={5}
+          onChangeEnd={val => handleSliderChange('surface', val)}
+        >
+          <RangeSliderTrack>
+            <RangeSliderFilledTrack />
+          </RangeSliderTrack>
+          <RangeSliderThumb index={0} />
+          <RangeSliderThumb index={1} />
+        </RangeSlider>
+        <Flex justify="space-between" mt={1}>
+          <Text>{searchParams.min_surface ?? 0} m²</Text>
+          <Text>{searchParams.max_surface ?? 500} m²</Text>
+        </Flex>
+      </Box>
+
+      <Divider />
+
+      <Flex justify="space-between" align="center">
+        <Text>Nombre de pièces</Text>
+        <HStack>
+          <IconButton icon={<FaMinus />} size="sm" onClick={() => decrement('rooms')} />
+          <Box minW="32px" textAlign="center">{searchParams.rooms ?? 0}</Box>
+          <IconButton icon={<FaPlus />} size="sm" onClick={() => increment('rooms')} />
+        </HStack>
+      </Flex>
+
+      <Flex justify="space-between" align="center">
+        <Text>Chambres</Text>
+        <HStack>
+          <IconButton icon={<FaMinus />} size="sm" onClick={() => decrement('bedrooms')} />
+          <Box minW="32px" textAlign="center">{searchParams.bedrooms ?? 0}</Box>
+          <IconButton icon={<FaPlus />} size="sm" onClick={() => increment('bedrooms')} />
+        </HStack>
+      </Flex>
+
+      <Divider />
+
+      <VStack align="stretch">
+        <Checkbox
+          name="has_terrace"
+          isChecked={!!searchParams.has_terrace}
+          onChange={handleCheckboxChange}
+        >
+          Terrasse
+        </Checkbox>
+        <Checkbox
+          name="has_parking"
+          isChecked={!!searchParams.has_parking}
+          onChange={handleCheckboxChange}
+        >
+          Parking
+        </Checkbox>
+      </VStack>
+
+      <Button colorScheme="green" onClick={onSearch}>Rechercher</Button>
+    </VStack>
+  );
+}

--- a/resources/js/Components/Listing/ListingCard.jsx
+++ b/resources/js/Components/Listing/ListingCard.jsx
@@ -4,9 +4,10 @@ import {
     Text,
     Stack,
     Flex,
-    Icon,
     HStack,
-    Image, IconButton,
+    Image,
+    IconButton,
+    Button,
 } from "@chakra-ui/react";
 import { Link } from "@inertiajs/react";
 import {FaHeart, FaRegHeart, FaStar} from "react-icons/fa";
@@ -43,45 +44,46 @@ export default function ListingCard({ listing }) {
         : JSON.parse(listing.photos || '[]');
 
     return (
-        <Link href={`/listings/${listing.id}`}>
-            <Box
-                borderRadius="lg"
-                overflow="hidden"
-                bg="white"
-                boxShadow="md"
-                transition="transform 0.2s"
-                _hover={{ transform: "scale(1.01)" }}
-            >
-                {/* Image Carousel Horizontal */}
-                <Flex overflowX="auto" gap={2}>
-                    {photos.map((photo, idx) => (
-                        <Image
-                            key={idx}
-                            src={photo || "/placeholder.jpg"}
-                            alt={`Photo ${idx + 1}`}
-                            objectFit="cover"
-                            height="180px"
-                            minW="300px"
-                            borderRadius="md"
-                        />
-                    ))}
-                </Flex>
+        <Box
+            borderRadius="lg"
+            overflow="hidden"
+            bg="white"
+            boxShadow="md"
+            position="relative"
+            transition="transform 0.2s"
+            _hover={{ transform: "scale(1.01)" }}
+        >
+            <Flex overflowX="auto" gap={2}>
+                {photos.map((photo, idx) => (
+                    <Image
+                        key={idx}
+                        src={photo || "/placeholder.jpg"}
+                        alt={`Photo ${idx + 1}`}
+                        objectFit="cover"
+                        height="180px"
+                        minW="300px"
+                        borderRadius="md"
+                    />
+                ))}
+            </Flex>
 
-                {/* Content */}
-                <Box p={4}>
-                    <Stack spacing={1}>
-                        <Text fontSize="lg" fontWeight="bold">{listing.title}</Text>
-                        <Text fontSize="sm" color="gray.600">{listing.city}, {listing.postal_code}</Text>
-                        <Text fontSize="md" fontWeight="bold">{listing.price} € <Text as="span" fontWeight="normal" color="gray.500">par nuit</Text></Text>
-                        <Text fontSize="sm" color="gray.600">Surface: {listing.surface} m²</Text>
-                        <Text fontSize="sm" color="gray.600">Pièces: {listing.rooms}, Chambres: {listing.bedrooms}</Text>
-                        <HStack spacing={1} color="yellow.400">
-                            <FavoriteButton listingId={listing.id} isFavorited={listing.is_favorited} />
-
-                        </HStack>
-                    </Stack>
-                </Box>
+            <Box p={4} pb={6}>
+                <Stack spacing={1}>
+                    <Text fontSize="lg" fontWeight="bold">{listing.title}</Text>
+                    <Text fontSize="sm" color="gray.600">{listing.city}, {listing.postal_code}</Text>
+                    <Text fontSize="md" fontWeight="bold">{listing.price} €<Text as="span" fontWeight="normal" color="gray.500"> par nuit</Text></Text>
+                    <Text fontSize="sm" color="gray.600">Surface: {listing.surface} m²</Text>
+                    <Text fontSize="sm" color="gray.600">Pièces: {listing.rooms}, Chambres: {listing.bedrooms}, Sdb: {listing.bathrooms}</Text>
+                    <HStack spacing={2} mt={2}>
+                        {listing.has_terrace && <Text fontSize="xs" color="gray.600">Terrasse</Text>}
+                        {listing.has_parking && <Text fontSize="xs" color="gray.600">Parking</Text>}
+                    </HStack>
+                </Stack>
             </Box>
-        </Link>
+            <Box px={4} pb={4} display="flex" justifyContent="space-between" alignItems="center">
+                <Button as={Link} href={`/listings/${listing.id}`} colorScheme="blue" size="sm">Voir l'annonce</Button>
+                <FavoriteButton listingId={listing.id} isFavorited={listing.is_favorited} />
+            </Box>
+        </Box>
     );
 }

--- a/resources/js/Pages/Listing/Favorites.jsx
+++ b/resources/js/Pages/Listing/Favorites.jsx
@@ -1,0 +1,18 @@
+import MainLayout from '@/Components/Layout/MainLayout';
+import ListingCard from '@/Components/Listing/ListingCard';
+import { Heading, SimpleGrid, Box } from '@chakra-ui/react';
+
+export default function Favorites({ favorites = [] }) {
+  return (
+    <MainLayout>
+      <Box>
+        <Heading size="lg" mb={6}>Mes favoris</Heading>
+        <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={6}>
+          {favorites.map((l) => (
+            <ListingCard key={l.id} listing={l} />
+          ))}
+        </SimpleGrid>
+      </Box>
+    </MainLayout>
+  );
+}

--- a/resources/js/Pages/Listing/Search.jsx
+++ b/resources/js/Pages/Listing/Search.jsx
@@ -1,15 +1,42 @@
-import { Box, Heading, SimpleGrid } from "@chakra-ui/react";
+import { Box, Heading, SimpleGrid, Flex } from "@chakra-ui/react";
+import MainLayout from "@/Components/Layout/MainLayout";
+import { useState } from "react";
+import { router } from "@inertiajs/react";
+import { route } from "ziggy-js";
 import ListingCard from "@/Components/Listing/ListingCard";
+import FilterSidebar from "@/Components/Listing/FilterSidebar";
 
-export default function Search({ listings = [] }) {
+export default function Search({ listings = [], filters = {} }) {
+  const [searchParams, setSearchParams] = useState(filters);
+
+  const handleSearch = () => {
+    router.visit(route('listings.search'), {
+      method: 'get',
+      data: searchParams,
+      preserveScroll: true,
+      preserveState: true,
+    });
+  };
+
   return (
-    <Box>
-      <Heading size="lg" mb={6}>Résultats de recherche</Heading>
-      <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={6}>
-        {listings.map((l) => (
-          <ListingCard key={l.id} listing={l} />
-        ))}
-      </SimpleGrid>
-    </Box>
+    <MainLayout>
+    <Flex gap={6} align="flex-start">
+      <Box w={{ base: '100%', md: '300px' }}>
+        <FilterSidebar
+          searchParams={searchParams}
+          setSearchParams={setSearchParams}
+          onSearch={handleSearch}
+        />
+      </Box>
+      <Box flex="1">
+        <Heading size="lg" mb={6}>Résultats de recherche</Heading>
+        <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={6}>
+          {listings.map((l) => (
+            <ListingCard key={l.id} listing={l} />
+          ))}
+        </SimpleGrid>
+      </Box>
+    </Flex>
+    </MainLayout>
   );
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,6 +68,7 @@ Route::middleware(['auth'])->group(function () {
 Route::get('/', [PageController::class, 'home'])->name('home');
 Route::get('/listings/search', [PageController::class, 'search'])->name('listings.search'); // Vue Inertia
 Route::get('/api/listings', [ListingController::class, 'index'])->name('listings.index');   // API JSON
+Route::get('/listings/{listing}', [PageController::class, 'listingShow'])->name('listings.show');
 
 Route::get('/login', [PageController::class, 'login'])->name('login');
 Route::get('/register', [PageController::class, 'register'])->name('register');
@@ -76,6 +77,7 @@ Route::get('/reset-password/{token}', [PageController::class, 'resetPassword'])-
 Route::get('/verify-sms', [PageController::class, 'smsCode'])->name('verify.sms');
 Route::get('/upload-identity', [PageController::class, 'uploadIdentity'])->name('verify.identity');
 Route::middleware(['auth'])->group(function () {
+    Route::get('/favorites', [PageController::class, 'favorites'])->name('favorites.index');
     Route::post('/listings/{listing}/favorite', [ListingController::class, 'toggle'])->name('favorites.toggle');
 });
 Route::middleware(['auth'])->group(function () {


### PR DESCRIPTION
## Summary
- add `scopeFilter` to `Listing` model for reusability
- update listing controller to use the new scope
- return listing search results with filters via `PageController`
- add routes and pages for listing details and favorites
- show more info in listing cards and add details button
- add sticky left filter sidebar on search page

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645f3c0edc83308e6a3f928f6ea9b2