### PR TITLE
Add call to action on homepage

### DIFF
--- a/resources/js/Components/Home/CreateListingCTA.jsx
+++ b/resources/js/Components/Home/CreateListingCTA.jsx
@@ -1,0 +1,29 @@
+import { Box, Heading, Text, SimpleGrid, Image, Button } from "@chakra-ui/react";
+import { Link } from "@inertiajs/react";
+
+export default function CreateListingCTA() {
+  return (
+    <Box bg="gray.50" py={10} px={{ base: 4, md: 8 }}>
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={8} alignItems="center">
+        <Image
+          src="/images/hero.png"
+          alt="Publier une annonce"
+          borderRadius="lg"
+          objectFit="cover"
+        />
+        <Box textAlign={{ base: "center", md: "left" }}>
+          <Heading as="h2" size="xl" mb={4}>
+            Envie de vendre ou louer un bien ?
+          </Heading>
+          <Text fontSize="lg" mb={6}>
+            Publiez votre annonce en quelques minutes et touchez des milliers
+            d’acheteurs potentiels sur ProprioPlus.
+          </Text>
+          <Button as={Link} href="/listings/create" colorScheme="brand" size="lg">
+            Créer une annonce
+          </Button>
+        </Box>
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/resources/js/Pages/Home/Index.jsx
+++ b/resources/js/Pages/Home/Index.jsx
@@ -9,6 +9,7 @@ import {
 } from "@chakra-ui/react";
 import SearchBar from "@/Components/Listing/SearchBar.jsx";
 import FeatureSection from "@/Components/Listing/FeatureSection";
+import CreateListingCTA from "@/Components/Home/CreateListingCTA";
 
 export default function Home() {
   const heroHeight = useBreakpointValue({ base: "240px", md: "320px", lg: "400px" });
@@ -36,6 +37,7 @@ export default function Home() {
         </Box>
 
         <FeatureSection />
+        <CreateListingCTA />
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- create `CreateListingCTA` component with a call-to-action to publish a new listing
- embed the call-to-action section in the home page

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864616666c08330a0a7bbe329c97b43