### PR TITLE
Improve search filters and theme

### DIFF
--- a/resources/js/Components/Listing/FilterSidebar.jsx
+++ b/resources/js/Components/Listing/FilterSidebar.jsx
@@ -123,7 +123,7 @@ export default function FilterSidebar({ searchParams, setSearchParams, onSearch 
         </Checkbox>
       </VStack>
 
-      <Button colorScheme="green" onClick={onSearch}>Rechercher</Button>
+      <Button colorScheme="brand" onClick={onSearch}>Rechercher</Button>
     </VStack>
   );
 }

--- a/resources/js/Components/Listing/ListingCard.jsx
+++ b/resources/js/Components/Listing/ListingCard.jsx
@@ -81,7 +81,7 @@ export default function ListingCard({ listing }) {
                 </Stack>
             </Box>
             <Box px={4} pb={4} display="flex" justifyContent="space-between" alignItems="center">
-                <Button as={Link} href={`/listings/${listing.id}`} colorScheme="blue" size="sm">Voir l'annonce</Button>
+                <Button as={Link} href={`/listings/${listing.id}`} colorScheme="brand" size="sm">Voir l'annonce</Button>
                 <FavoriteButton listingId={listing.id} isFavorited={listing.is_favorited} />
             </Box>
         </Box>

--- a/resources/js/Components/Listing/ResponsiveFilters.jsx
+++ b/resources/js/Components/Listing/ResponsiveFilters.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  useBreakpointValue,
+  useDisclosure,
+} from '@chakra-ui/react';
+import FilterSidebar from './FilterSidebar';
+
+export default function ResponsiveFilters({ searchParams, setSearchParams, onSearch }) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const isMobile = useBreakpointValue({ base: true, md: false });
+
+  if (isMobile) {
+    return (
+      <>
+        <Button mb={4} onClick={onOpen} colorScheme="brand">
+          Filtres
+        </Button>
+        <Drawer placement="left" isOpen={isOpen} onClose={onClose}>
+          <DrawerOverlay />
+          <DrawerContent>
+            <DrawerCloseButton />
+            <DrawerHeader>Filtres</DrawerHeader>
+            <DrawerBody>
+              <FilterSidebar
+                searchParams={searchParams}
+                setSearchParams={setSearchParams}
+                onSearch={() => {
+                  onSearch();
+                  onClose();
+                }}
+              />
+            </DrawerBody>
+          </DrawerContent>
+        </Drawer>
+      </>
+    );
+  }
+
+  return (
+    <Box w="300px">
+      <FilterSidebar
+        searchParams={searchParams}
+        setSearchParams={setSearchParams}
+        onSearch={onSearch}
+      />
+    </Box>
+  );
+}
+

--- a/resources/js/Pages/Listing/Search.jsx
+++ b/resources/js/Pages/Listing/Search.jsx
@@ -1,10 +1,9 @@
 import { Box, Heading, SimpleGrid, Flex } from "@chakra-ui/react";
-import MainLayout from "@/Components/Layout/MainLayout";
 import { useState } from "react";
 import { router } from "@inertiajs/react";
 import { route } from "ziggy-js";
 import ListingCard from "@/Components/Listing/ListingCard";
-import FilterSidebar from "@/Components/Listing/FilterSidebar";
+import ResponsiveFilters from "@/Components/Listing/ResponsiveFilters";
 
 export default function Search({ listings = [], filters = {} }) {
   const [searchParams, setSearchParams] = useState(filters);
@@ -19,15 +18,12 @@ export default function Search({ listings = [], filters = {} }) {
   };
 
   return (
-    <MainLayout>
-    <Flex gap={6} align="flex-start">
-      <Box w={{ base: '100%', md: '300px' }}>
-        <FilterSidebar
-          searchParams={searchParams}
-          setSearchParams={setSearchParams}
-          onSearch={handleSearch}
-        />
-      </Box>
+    <Flex gap={6} align="flex-start" direction={{ base: 'column', md: 'row' }}>
+      <ResponsiveFilters
+        searchParams={searchParams}
+        setSearchParams={setSearchParams}
+        onSearch={handleSearch}
+      />
       <Box flex="1">
         <Heading size="lg" mb={6}>Résultats de recherche</Heading>
         <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={6}>
@@ -37,6 +33,5 @@ export default function Search({ listings = [], filters = {} }) {
         </SimpleGrid>
       </Box>
     </Flex>
-    </MainLayout>
   );
 }

--- a/resources/js/theme.js
+++ b/resources/js/theme.js
@@ -7,13 +7,33 @@ const theme = extendTheme({
   },
   colors: {
     brand: {
-      500: '#FF3C00',
+      50: '#ffeae9',
+      100: '#ffc9c5',
+      200: '#ffa39d',
+      300: '#ff7c75',
+      400: '#ff5a54',
+      500: '#ff453f',
+      600: '#e63a37',
+      700: '#cc2f2f',
+      800: '#b32427',
+      900: '#8a181b',
+    },
+  },
+  styles: {
+    global: {
+      body: {
+        bg: 'gray.50',
+        color: 'gray.800',
+      },
     },
   },
   components: {
     Button: {
       baseStyle: {
         borderRadius: 'xl',
+      },
+      defaultProps: {
+        colorScheme: 'brand',
       },
     },
   },


### PR DESCRIPTION
## Summary
- update Chakra global theme with brand palette and defaults
- add responsive filter drawer for small screens
- fix search page layout to avoid double nav/footer
- use brand color for buttons

## Testing
- `npm run build` *(fails: vite not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864633a18408330b86e22c8b30765d3