### PR TITLE
Add account settings page with sidebar

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Inertia\Inertia;
 use Illuminate\Http\Request;
 use App\Models\Listing;
+use App\Models\User;
 
 class PageController extends Controller
 {
@@ -88,7 +89,11 @@ class PageController extends Controller
 
     public function accountSettings()
     {
-        return Inertia::render('Account/Settings');
+        $user = auth()->id() ? User::withBasicInfo()->find(auth()->id()) : null;
+
+        return Inertia::render('Account/Settings', [
+            'user' => $user,
+        ]);
     }
 }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,6 +24,11 @@ class User extends Authenticatable implements MustVerifyEmail
         'email_verified_at' => 'datetime',
         'certification_date' => 'datetime',
     ];
+
+    public function scopeWithBasicInfo($query)
+    {
+        return $query->select('id', 'first_name', 'last_name', 'email', 'phone');
+    }
     public function favorites()
     {
         return $this->belongsToMany(Listing::class, 'favorites')->withTimestamps();

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -27,7 +27,9 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
+            'first_name' => fake()->firstName(),
+            'last_name' => fake()->lastName(),
+            'phone' => fake()->phoneNumber(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),

--- a/resources/js/Components/Account/PasswordForm.jsx
+++ b/resources/js/Components/Account/PasswordForm.jsx
@@ -1,0 +1,43 @@
+import { useForm } from '@inertiajs/react';
+import { Box, FormControl, FormLabel, Input, FormErrorMessage, Button, VStack } from '@chakra-ui/react';
+import React from 'react';
+
+export default function PasswordForm() {
+  const { data, setData, put, processing, errors, reset } = useForm({
+    current_password: '',
+    password: '',
+    password_confirmation: '',
+  });
+
+  const submit = (e) => {
+    e.preventDefault();
+    put('/user/password', {
+      onSuccess: () => reset(),
+    });
+  };
+
+  return (
+    <Box as="form" onSubmit={submit} maxW="md">
+      <VStack spacing={4} align="stretch">
+        <FormControl isInvalid={errors.current_password}>
+          <FormLabel>Mot de passe actuel</FormLabel>
+          <Input type="password" value={data.current_password} onChange={(e) => setData('current_password', e.target.value)} />
+          <FormErrorMessage>{errors.current_password}</FormErrorMessage>
+        </FormControl>
+        <FormControl isInvalid={errors.password}>
+          <FormLabel>Nouveau mot de passe</FormLabel>
+          <Input type="password" value={data.password} onChange={(e) => setData('password', e.target.value)} />
+          <FormErrorMessage>{errors.password}</FormErrorMessage>
+        </FormControl>
+        <FormControl isInvalid={errors.password_confirmation}>
+          <FormLabel>Confirmez le mot de passe</FormLabel>
+          <Input type="password" value={data.password_confirmation} onChange={(e) => setData('password_confirmation', e.target.value)} />
+          <FormErrorMessage>{errors.password_confirmation}</FormErrorMessage>
+        </FormControl>
+        <Button colorScheme="brand" type="submit" isLoading={processing} alignSelf="flex-start">
+          Mettre à jour
+        </Button>
+      </VStack>
+    </Box>
+  );
+}

--- a/resources/js/Components/Account/PersonalInfoForm.jsx
+++ b/resources/js/Components/Account/PersonalInfoForm.jsx
@@ -1,0 +1,47 @@
+import { useForm } from '@inertiajs/react';
+import { Box, FormControl, FormLabel, Input, FormErrorMessage, Button, VStack } from '@chakra-ui/react';
+import React from 'react';
+
+export default function PersonalInfoForm({ user }) {
+  const { data, setData, put, processing, errors } = useForm({
+    first_name: user?.first_name || '',
+    last_name: user?.last_name || '',
+    phone: user?.phone || '',
+    email: user?.email || '',
+  });
+
+  const submit = (e) => {
+    e.preventDefault();
+    put('/profile');
+  };
+
+  return (
+    <Box as="form" onSubmit={submit} maxW="md">
+      <VStack spacing={4} align="stretch">
+        <FormControl isInvalid={errors.first_name}>
+          <FormLabel>Prénom</FormLabel>
+          <Input value={data.first_name} onChange={(e) => setData('first_name', e.target.value)} />
+          <FormErrorMessage>{errors.first_name}</FormErrorMessage>
+        </FormControl>
+        <FormControl isInvalid={errors.last_name}>
+          <FormLabel>Nom</FormLabel>
+          <Input value={data.last_name} onChange={(e) => setData('last_name', e.target.value)} />
+          <FormErrorMessage>{errors.last_name}</FormErrorMessage>
+        </FormControl>
+        <FormControl isInvalid={errors.phone}>
+          <FormLabel>Téléphone</FormLabel>
+          <Input value={data.phone} onChange={(e) => setData('phone', e.target.value)} />
+          <FormErrorMessage>{errors.phone}</FormErrorMessage>
+        </FormControl>
+        <FormControl isInvalid={errors.email}>
+          <FormLabel>Email</FormLabel>
+          <Input type="email" value={data.email} onChange={(e) => setData('email', e.target.value)} />
+          <FormErrorMessage>{errors.email}</FormErrorMessage>
+        </FormControl>
+        <Button colorScheme="brand" type="submit" isLoading={processing} alignSelf="flex-start">
+          Enregistrer
+        </Button>
+      </VStack>
+    </Box>
+  );
+}

--- a/resources/js/Pages/Account/Settings.jsx
+++ b/resources/js/Pages/Account/Settings.jsx
@@ -1,11 +1,29 @@
 import React from 'react';
-import { Box, Heading, Text } from '@chakra-ui/react';
+import { Box, Heading, Tabs, TabList, TabPanels, Tab, TabPanel } from '@chakra-ui/react';
+import { usePage } from '@inertiajs/react';
+import PersonalInfoForm from '@/Components/Account/PersonalInfoForm';
+import PasswordForm from '@/Components/Account/PasswordForm';
 
-export default function Settings() {
+export default function Settings({ user }) {
+  const pageUser = user || usePage().props.user;
+
   return (
     <Box p={8}>
-      <Heading size="lg" mb={4}>Paramètres du compte</Heading>
-      <Text>Cette page permettra à l\'utilisateur de gérer les informations de son compte.</Text>
+      <Heading size="lg" mb={6}>Paramètres du compte</Heading>
+      <Tabs orientation="vertical" variant="line" isLazy display={{ md: 'flex' }}>
+        <TabList minW="200px" borderRight="1px" borderColor="gray.200">
+          <Tab>Informations personnelles</Tab>
+          <Tab>Mot de passe</Tab>
+        </TabList>
+        <TabPanels flex="1" pl={{ md: 6 }} mt={{ base: 4, md: 0 }}>
+          <TabPanel px={0}>
+            <PersonalInfoForm user={pageUser} />
+          </TabPanel>
+          <TabPanel px={0}>
+            <PasswordForm />
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- update `UserFactory` to use new columns
- add `withBasicInfo` scope to `User`
- return authenticated user from `accountSettings` controller
- create forms for personal information and password update
- design account settings page with sidebar navigation

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6864670b301c83309617495086f433a6