### PR TITLE
Add notification dropdown with controls

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -3,12 +3,25 @@ namespace App\Http\Controllers;
 
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Support\Facades\Auth;
+use App\Models\User;
 
 class NotificationController extends Controller
 {
     public function index()
     {
-        return response()->json(Auth::user()->unreadNotifications);
+        $notifications = Auth::user()->notifications()->latest()->get()->map(function ($notification) {
+            $sender = User::withBasicInfo()->find($notification->data['sender_id']);
+
+            return [
+                'id' => $notification->id,
+                'read_at' => $notification->read_at,
+                'created_at' => $notification->created_at,
+                'data' => $notification->data,
+                'sender' => $sender,
+            ];
+        });
+
+        return response()->json($notifications);
     }
 
     public function markAsRead(DatabaseNotification $notification)
@@ -18,5 +31,14 @@ class NotificationController extends Controller
         }
         $notification->markAsRead();
         return response()->json(['message' => 'Notification lue']);
+    }
+
+    public function markAsUnread(DatabaseNotification $notification)
+    {
+        if ($notification->notifiable_id !== Auth::id()) {
+            abort(403);
+        }
+        $notification->update(['read_at' => null]);
+        return response()->json(['message' => 'Notification non lue']);
     }
 }

--- a/resources/js/Components/UI/NotificationBell.jsx
+++ b/resources/js/Components/UI/NotificationBell.jsx
@@ -1,23 +1,84 @@
-import { Box, IconButton, Badge } from '@chakra-ui/react';
+import {
+  Box,
+  IconButton,
+  Badge,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  Avatar,
+  HStack,
+  Text,
+  Button,
+} from '@chakra-ui/react';
 import { BellIcon } from '@chakra-ui/icons';
 import { Link, usePage } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
 
 export default function NotificationBell() {
   const { unreadNotifications = 0 } = usePage().props;
+  const [notifications, setNotifications] = useState([]);
+
+  const loadNotifications = async () => {
+    try {
+      const res = await axios.get('/notifications');
+      setNotifications(res.data);
+    } catch (e) {}
+  };
+
+  useEffect(() => {
+    loadNotifications();
+  }, []);
+
+  const markAsRead = async (id) => {
+    await axios.post(`/notifications/${id}/read`);
+    setNotifications((ns) => ns.map((n) => (n.id === id ? { ...n, read_at: new Date().toISOString() } : n)));
+  };
+
+  const markAsUnread = async (id) => {
+    await axios.post(`/notifications/${id}/unread`);
+    setNotifications((ns) => ns.map((n) => (n.id === id ? { ...n, read_at: null } : n)));
+  };
+
+  const unreadCount = notifications.filter((n) => !n.read_at).length || unreadNotifications;
+
   return (
-    <Box position="relative" mr={2}>
-      <IconButton
-        as={Link}
-        href="/messages"
-        icon={<BellIcon />}
-        variant="ghost"
-        aria-label="Notifications"
-      />
-      {unreadNotifications > 0 && (
-        <Badge position="absolute" top="0" right="0" bg="brand.500" color="white" borderRadius="full">
-          {unreadNotifications}
-        </Badge>
-      )}
-    </Box>
+    <Menu>
+      <MenuButton as={IconButton} variant="ghost" icon={<BellIcon />} aria-label="Notifications" position="relative" mr={2}>
+        {unreadCount > 0 && (
+          <Badge position="absolute" top="0" right="0" bg="brand.500" color="white" borderRadius="full">
+            {unreadCount}
+          </Badge>
+        )}
+      </MenuButton>
+      <MenuList maxW="300px">
+        {notifications.length === 0 ? (
+          <MenuItem>Aucune notification</MenuItem>
+        ) : (
+          notifications.map((n) => (
+            <MenuItem
+              key={n.id}
+              bg={n.read_at ? 'white' : 'gray.100'}
+              _hover={{ bg: n.read_at ? 'gray.50' : 'gray.200' }}
+              as={Link}
+              href={`/messages?conversation=${n.data.conversation_id}`}
+            >
+              <HStack align="start" spacing={3} w="100%">
+                <Avatar size="sm" name={`${n.sender.first_name} ${n.sender.last_name}`} />
+                <Box flex="1">
+                  <Text fontSize="sm" mb={1}>{n.data.content}</Text>
+                  {n.read_at ? (
+                    <Button size="xs" onClick={(e) => { e.preventDefault(); markAsUnread(n.id); }}>Marquer comme non lue</Button>
+                  ) : (
+                    <Button size="xs" onClick={(e) => { e.preventDefault(); markAsRead(n.id); }}>Marquer comme lue</Button>
+                  )}
+                </Box>
+              </HStack>
+            </MenuItem>
+          ))
+        )}
+      </MenuList>
+    </Menu>
   );
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,6 +65,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::get('/notifications', [NotificationController::class, 'index']);
     Route::post('/notifications/{notification}/read', [NotificationController::class, 'markAsRead']);
+    Route::post('/notifications/{notification}/unread', [NotificationController::class, 'markAsUnread']);
 });
 Route::middleware(['auth'])->group(function () {
     Route::get('/reports', [ReportController::class, 'index']);


### PR DESCRIPTION
## Summary
- improve notification controller to return sender info, allow unread action
- expose a new route to mark notifications as unread
- update NotificationBell component to show a dropdown list with read/unread actions

## Testing
- `phpunit -c phpunit.xml --stop-on-failure` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864716a97408330a65b27dea7e7c20c