### PR TITLE
Improve listing creation UI

### DIFF
--- a/resources/js/Pages/Listing/Create.jsx
+++ b/resources/js/Pages/Listing/Create.jsx
@@ -1,10 +1,11 @@
 import { useForm } from '@inertiajs/react';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import {
   Box,
   Button,
   FormControl,
   FormLabel,
+  FormErrorMessage,
   Input,
   Textarea,
   Select,
@@ -13,7 +14,9 @@ import {
   VStack,
   SimpleGrid,
   Image,
-  Heading
+  Heading,
+  Text,
+  Progress,
 } from '@chakra-ui/react';
 import AddressSearch from '@/Components/Listing/AddressSearch';
 
@@ -70,16 +73,22 @@ export default function Create({ categories = [] }) {
 
   return (
     <Box as="form" onSubmit={submit} maxW="4xl" mx="auto" bg="white" p={6} rounded="md" boxShadow="md">
-      <Heading size="lg" mb={6}>Créer une annonce</Heading>
+      <Heading size="lg" mb={4}>Créer une annonce</Heading>
+      <Flex align="center" mb={6} gap={4}>
+        <Text fontWeight="bold">Étape {step} / 4</Text>
+        <Progress value={(step / 4) * 100} flex="1" size="sm" colorScheme="brand" rounded="md" />
+      </Flex>
       {step === 1 && (
         <VStack spacing={4} align="stretch">
           <FormControl isInvalid={errors.title}>
             <FormLabel>Titre</FormLabel>
             <Input value={data.title} onChange={(e) => setData('title', e.target.value)} />
+            <FormErrorMessage>{errors.title}</FormErrorMessage>
           </FormControl>
           <FormControl isInvalid={errors.description}>
             <FormLabel>Description</FormLabel>
             <Textarea value={data.description} onChange={(e) => setData('description', e.target.value)} />
+            <FormErrorMessage>{errors.description}</FormErrorMessage>
           </FormControl>
           <FormControl isInvalid={errors.category_id}>
             <FormLabel>Catégorie</FormLabel>
@@ -89,6 +98,7 @@ export default function Create({ categories = [] }) {
                 <option key={c.id} value={c.id}>{c.name}</option>
               ))}
             </Select>
+            <FormErrorMessage>{errors.category_id}</FormErrorMessage>
           </FormControl>
         </VStack>
       )}
@@ -98,14 +108,17 @@ export default function Create({ categories = [] }) {
           <FormControl isInvalid={errors.price}>
             <FormLabel>Prix</FormLabel>
             <Input type="number" value={data.price} onChange={(e) => setData('price', e.target.value)} />
+            <FormErrorMessage>{errors.price}</FormErrorMessage>
           </FormControl>
           <FormControl isInvalid={errors.surface}>
             <FormLabel>Surface (m²)</FormLabel>
             <Input type="number" value={data.surface} onChange={(e) => setData('surface', e.target.value)} />
+            <FormErrorMessage>{errors.surface}</FormErrorMessage>
           </FormControl>
           <FormControl isInvalid={errors.rooms}>
             <FormLabel>Pièces</FormLabel>
             <Input type="number" value={data.rooms} onChange={(e) => setData('rooms', e.target.value)} />
+            <FormErrorMessage>{errors.rooms}</FormErrorMessage>
           </FormControl>
           <FormControl>
             <FormLabel>Chambres</FormLabel>
@@ -141,19 +154,22 @@ export default function Create({ categories = [] }) {
 
       {step === 3 && (
         <VStack spacing={4} align="stretch">
-          <FormControl>
+          <FormControl isInvalid={errors.address}>
             <FormLabel>Adresse</FormLabel>
             <Input value={data.address} onChange={(e) => setData('address', e.target.value)} />
+            <FormErrorMessage>{errors.address}</FormErrorMessage>
           </FormControl>
           <AddressSearch onSelect={handleAddressSelect} />
           <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
             <FormControl isInvalid={errors.city}>
               <FormLabel>Ville</FormLabel>
               <Input value={data.city} onChange={(e) => setData('city', e.target.value)} />
+              <FormErrorMessage>{errors.city}</FormErrorMessage>
             </FormControl>
             <FormControl isInvalid={errors.postal_code}>
               <FormLabel>Code postal</FormLabel>
               <Input value={data.postal_code} onChange={(e) => setData('postal_code', e.target.value)} />
+              <FormErrorMessage>{errors.postal_code}</FormErrorMessage>
             </FormControl>
           </SimpleGrid>
         </VStack>
@@ -161,9 +177,10 @@ export default function Create({ categories = [] }) {
 
       {step === 4 && (
         <VStack spacing={4} align="stretch">
-          <FormControl>
+          <FormControl isInvalid={errors.gallery}>
             <FormLabel>Photos</FormLabel>
             <Input type="file" multiple onChange={handleGalleryChange} />
+            <FormErrorMessage>{errors.gallery}</FormErrorMessage>
           </FormControl>
           {previews.length > 0 && (
             <SimpleGrid columns={{ base: 2, md: 4 }} spacing={4}>
@@ -172,9 +189,10 @@ export default function Create({ categories = [] }) {
               ))}
             </SimpleGrid>
           )}
-          <FormControl>
+          <FormControl isInvalid={errors.documents}>
             <FormLabel>Documents</FormLabel>
             <Input type="file" multiple onChange={handleDocumentsChange} />
+            <FormErrorMessage>{errors.documents}</FormErrorMessage>
           </FormControl>
         </VStack>
       )}


### PR DESCRIPTION
## Summary
- enhance listing creation form with error messages
- add step progress indicator for multi-step form

## Testing
- `composer install --no-progress` *(fails: composer not found)*
- `npm test --silent` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6864da3a19dc83308f39d801aa788f25