### PR TITLE
Add listing status scopes

### DIFF
--- a/app/Enums/ListingStatus.php
+++ b/app/Enums/ListingStatus.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\Enums;
+
+enum ListingStatus: string
+{
+    case Active = 'active';
+    case Sold = 'vendue';
+    case Archived = 'archivée';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -11,7 +11,7 @@ class HomeController extends Controller
     public function index()
     {
         $featured = Listing::with('gallery')
-            ->where('status', 'active')
+            ->active()
             ->latest()
             ->take(6)
             ->get();

--- a/app/Http/Controllers/ListingController.php
+++ b/app/Http/Controllers/ListingController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\StoreListingRequest;
 use App\Models\Favorite;
 use App\Models\Listing;
 use App\Models\Category;
+use App\Enums\ListingStatus;
 use Inertia\Inertia;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -17,7 +18,7 @@ class ListingController extends Controller
     {
         $listings = Listing::query()
             ->with('category', 'user')
-            ->where('status', 'active')
+            ->active()
             ->filter($request->all())
             ->withFavoriteStatus(auth()->id())
             ->paginate(10);
@@ -34,7 +35,7 @@ class ListingController extends Controller
     }
     public function all(Request $request): \Illuminate\Http\JsonResponse
     {
-        $listings = Listing::where('status', 'active')
+        $listings = Listing::active()
             ->whereNotNull('latitude')
             ->whereNotNull('longitude')
             ->filter($request->all())
@@ -54,7 +55,7 @@ class ListingController extends Controller
         $similar = Listing::where('category_id', $listing->category_id)
             ->where('id', '!=', $listing->id)
             ->where('city', $listing->city)
-            ->where('status', 'active')
+            ->active()
             ->withFavoriteStatus(auth()->id())
             ->limit(4)->get();
 
@@ -110,7 +111,7 @@ class ListingController extends Controller
     public function markAsSold(Listing $listing)
     {
         $this->authorize('update', $listing);
-        $listing->update(['status' => 'vendue']);
+        $listing->update(['status' => ListingStatus::Sold]);
 
         return response()->json(['message' => 'Annonce marquée comme vendue']);
     }
@@ -118,7 +119,7 @@ class ListingController extends Controller
     public function archive(Listing $listing)
     {
         $this->authorize('update', $listing);
-        $listing->update(['status' => 'archivée']);
+        $listing->update(['status' => ListingStatus::Archived]);
 
         return response()->json(['message' => 'Annonce archivée']);
     }

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -19,7 +19,7 @@ class PageController extends Controller
     {
         $listings = Listing::query()
             ->with('category', 'user')
-            ->where('status', 'active')
+            ->active()
             ->filter($request->all())
             ->withFavoriteStatus(auth()->id())
             ->get();
@@ -77,7 +77,7 @@ class PageController extends Controller
         $similar = Listing::where('category_id', $listing->category_id)
             ->where('id', '!=', $listing->id)
             ->where('city', $listing->city)
-            ->where('status', 'active')
+            ->active()
             ->withFavoriteStatus(auth()->id())
             ->limit(4)
             ->get();

--- a/app/Models/Listing.php
+++ b/app/Models/Listing.php
@@ -1,6 +1,8 @@
 <?php
 namespace App\Models;
 
+use App\Enums\ListingStatus;
+
 use Illuminate\Database\Eloquent\Model;
 
 class Listing extends Model
@@ -28,6 +30,10 @@ class Listing extends Model
         'status',
         'user_id',
         'category_id'
+    ];
+
+    protected $casts = [
+        'status' => ListingStatus::class,
     ];
 
     public function user() {
@@ -144,6 +150,27 @@ class Listing extends Model
         }
 
         return $query;
+    }
+
+    public function scopeStatus($query, ListingStatus|string $status)
+    {
+        $status = $status instanceof ListingStatus ? $status->value : $status;
+        return $query->where('status', $status);
+    }
+
+    public function scopeActive($query)
+    {
+        return $this->scopeStatus($query, ListingStatus::Active);
+    }
+
+    public function scopeSold($query)
+    {
+        return $this->scopeStatus($query, ListingStatus::Sold);
+    }
+
+    public function scopeArchived($query)
+    {
+        return $this->scopeStatus($query, ListingStatus::Archived);
     }
 
 


### PR DESCRIPTION
## Summary
- add `ListingStatus` enum for listings
- add status scopes on `Listing` model
- use new scopes in controllers for cleaner filtering

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686502f0fc8083308bfb9b535cd4cb12