### PR TITLE
Enable document uploads for listings

### DIFF
--- a/app/Http/Controllers/ListingController.php
+++ b/app/Http/Controllers/ListingController.php
@@ -128,6 +128,20 @@ class ListingController extends Controller
 
         $listing->update($data);
 
+        if ($request->hasFile('documents')) {
+            foreach ($request->file('documents') as $file) {
+                $path = $file->store('listing_documents', 'public');
+                $listing->documents()->create(['path' => $path, 'type' => 'document']);
+            }
+        }
+
+        if ($request->hasFile('gallery')) {
+            foreach ($request->file('gallery') as $file) {
+                $path = $file->store('listing_images', 'public');
+                $listing->gallery()->create(['path' => $path, 'type' => 'image']);
+            }
+        }
+
         $message = ($data['status'] ?? $listing->status?->value) === ListingStatus::Pending->value
             ? 'Annonce mise à jour et en attente de validation'
             : 'Annonce mise à jour';

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -8,7 +8,7 @@ class File extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['path', 'type'];
+    protected $fillable = ['path', 'type', 'fileable_id', 'fileable_type'];
 
     public function fileable()
     {

--- a/database/migrations/2025_06_22_000001_add_fileable_columns_to_files_table.php
+++ b/database/migrations/2025_06_22_000001_add_fileable_columns_to_files_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('files', function (Blueprint $table) {
+            $table->unsignedBigInteger('fileable_id')->nullable()->after('id');
+            $table->string('fileable_type')->nullable()->after('fileable_id');
+            $table->index(['fileable_id', 'fileable_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('files', function (Blueprint $table) {
+            $table->dropIndex(['fileable_id', 'fileable_type']);
+            $table->dropColumn(['fileable_id', 'fileable_type']);
+        });
+    }
+};

--- a/resources/js/Pages/Listing/Edit.jsx
+++ b/resources/js/Pages/Listing/Edit.jsx
@@ -50,6 +50,8 @@ export default function Edit({ listing, categories: initialCategories = [] }) {
     address: listing.address || '',
     latitude: listing.latitude || '',
     longitude: listing.longitude || '',
+    gallery: null,
+    documents: null,
   });
 
   const [categories, setCategories] = React.useState(initialCategories);
@@ -64,9 +66,17 @@ export default function Edit({ listing, categories: initialCategories = [] }) {
     setData(data => ({ ...data, city, postal_code, latitude: lat, longitude: lng }));
   };
 
+  const handleGalleryChange = e => {
+    setData('gallery', e.target.files);
+  };
+
+  const handleDocumentsChange = e => {
+    setData('documents', e.target.files);
+  };
+
   const submit = e => {
     e.preventDefault();
-    put(`/listings/${listing.id}`);
+    put(`/listings/${listing.id}`, { forceFormData: true });
   };
 
   const remove = () => {
@@ -167,6 +177,16 @@ export default function Edit({ listing, categories: initialCategories = [] }) {
             <FormErrorMessage>{errors.postal_code}</FormErrorMessage>
           </FormControl>
         </SimpleGrid>
+        <FormControl isInvalid={errors.gallery} mt={4}>
+          <FormLabel>Photos</FormLabel>
+          <Input type="file" multiple onChange={handleGalleryChange} />
+          <FormErrorMessage>{errors.gallery}</FormErrorMessage>
+        </FormControl>
+        <FormControl isInvalid={errors.documents}>
+          <FormLabel>Documents</FormLabel>
+          <Input type="file" multiple onChange={handleDocumentsChange} />
+          <FormErrorMessage>{errors.documents}</FormErrorMessage>
+        </FormControl>
       </VStack>
 
       <Flex justify="space-between" mt={6}>


### PR DESCRIPTION
## Summary
- add polymorphic columns to files table
- allow listings to upload documents and gallery updates
- store new files when editing a listing
- update edit page to support file uploads

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686536d1a1c48330ab44e2f0f3a45f72