### PR TITLE
Add basic admin user management

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -5,9 +5,18 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Inertia\Inertia;
 
 class UserController extends Controller
 {
+    public function index()
+    {
+        $users = User::withBasicInfo()->select('certification_status')->get();
+
+        return Inertia::render('Admin/Users/Index', [
+            'users' => $users,
+        ]);
+    }
     public function certify(User $user)
     {
         $user->update([

--- a/resources/js/Pages/Admin/Users/Index.jsx
+++ b/resources/js/Pages/Admin/Users/Index.jsx
@@ -1,0 +1,52 @@
+import { Box, Table, Thead, Tbody, Tr, Th, Td, Input, Button } from '@chakra-ui/react';
+import { useState, useMemo } from 'react';
+import { router } from '@inertiajs/react';
+import { route } from 'ziggy-js';
+
+export default function Index({ users = [] }) {
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase();
+    return users.filter(u => (
+      `${u.first_name} ${u.last_name} ${u.email}`.toLowerCase().includes(q)
+    ));
+  }, [query, users]);
+
+  const certify = (id) => {
+    router.post(route('admin.users.certify', id));
+  };
+
+  const refuse = (id) => {
+    router.post(route('admin.users.refuse', id));
+  };
+
+  return (
+    <Box>
+      <Input placeholder="Rechercher..." mb={4} value={query} onChange={(e) => setQuery(e.target.value)} />
+      <Table variant="striped" colorScheme="gray">
+        <Thead>
+          <Tr>
+            <Th>Nom</Th>
+            <Th>Email</Th>
+            <Th>Status</Th>
+            <Th>Actions</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {filtered.map(u => (
+            <Tr key={u.id}>
+              <Td>{u.first_name} {u.last_name}</Td>
+              <Td>{u.email}</Td>
+              <Td>{u.certification_status || '—'}</Td>
+              <Td>
+                <Button size="sm" mr={2} onClick={() => certify(u.id)}>Certifier</Button>
+                <Button size="sm" variant="outline" onClick={() => refuse(u.id)}>Refuser</Button>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+}

--- a/resources/scss/admin.scss
+++ b/resources/scss/admin.scss
@@ -1,0 +1,4 @@
+.table-actions {
+  display: flex;
+  gap: 0.25rem;
+}

--- a/resources/scss/index.scss
+++ b/resources/scss/index.scss
@@ -4,3 +4,5 @@ body {
   margin: 0;
   padding: 0;
 }
+
+@import 'admin';

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
+use App\Http\Middleware\EnsureIsAdmin;
 use Illuminate\Http\Request;
 
 use Inertia\Inertia;
@@ -45,10 +46,14 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/certification', [CertificationController::class, 'showForm'])->name('certification.form');
     Route::post('/certification', [CertificationController::class, 'submitDocument'])->name('certification.submit');
 });
-Route::middleware(['auth', 'verified'])->prefix('admin')->name('admin.')->group(function () {
-    Route::post('/users/{user}/certify', [AdminUserController::class, 'certify'])->name('users.certify');
-    Route::post('/users/{user}/refuse', [AdminUserController::class, 'refuse'])->name('users.refuse');
-});
+Route::middleware(['auth', 'verified', EnsureIsAdmin::class])
+    ->prefix('admin')
+    ->name('admin.')
+    ->group(function () {
+        Route::get('/users', [AdminUserController::class, 'index'])->name('users.index');
+        Route::post('/users/{user}/certify', [AdminUserController::class, 'certify'])->name('users.certify');
+        Route::post('/users/{user}/refuse', [AdminUserController::class, 'refuse'])->name('users.refuse');
+    });
 Route::middleware(['auth', 'verified', 'certified'])->group(function () {
     Route::resource('listings', ListingController::class)->except(['show']);
     Route::post('listings/{listing}/mark-as-sold', [ListingController::class, 'markAsSold'])->name('listings.sold');

--- a/tests/Feature/AdminUserAccessTest.php
+++ b/tests/Feature/AdminUserAccessTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Role;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminUserAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_non_admin_cannot_access_admin_routes(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/admin/users');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_can_access_user_index(): void
+    {
+        $admin = User::factory()->create();
+        $role = Role::create(['name' => 'admin']);
+        $admin->roles()->attach($role);
+
+        $response = $this->actingAs($admin)->get('/admin/users');
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- secure admin routes with middleware
- implement admin user index in controller
- style admin area with SCSS
- add React admin user table
- cover admin access with tests

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653d87b93c833097ad84dcf4161973