### PR TITLE
Add dynamic user admin table

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -11,11 +11,28 @@ class UserController extends Controller
 {
     public function index()
     {
-        $users = User::withBasicInfo()->select('certification_status')->get();
+        return Inertia::render('Admin/Users/Index');
+    }
 
-        return Inertia::render('Admin/Users/Index', [
-            'users' => $users,
-        ]);
+    public function data(Request $request)
+    {
+        $query = User::withBasicInfo()->select('certification_status');
+
+        if ($search = $request->input('search')) {
+            $query->where(function ($q) use ($search) {
+                $q->where('first_name', 'like', "%{$search}%")
+                    ->orWhere('last_name', 'like', "%{$search}%")
+                    ->orWhere('email', 'like', "%{$search}%");
+            });
+        }
+
+        $sort = $request->input('sort', 'id');
+        $dir = $request->input('dir', 'asc');
+        $query->orderBy($sort, $dir);
+
+        $perPage = (int) $request->input('per_page', 10);
+
+        return $query->paginate($perPage);
     }
     public function certify(User $user)
     {

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -17,15 +17,7 @@ class PageController extends Controller
 
     public function search(Request $request)
     {
-        $listings = Listing::query()
-            ->with('category', 'user')
-            ->active()
-            ->filter($request->all())
-            ->withFavoriteStatus(auth()->id())
-            ->get();
-
         return Inertia::render('Listing/Search', [
-            'listings' => $listings,
             'filters' => $request->all(),
         ]);
     }

--- a/resources/js/Pages/Admin/Users/Index.jsx
+++ b/resources/js/Pages/Admin/Users/Index.jsx
@@ -1,40 +1,68 @@
-import { Box, Table, Thead, Tbody, Tr, Th, Td, Input, Button } from '@chakra-ui/react';
-import { useState, useMemo } from 'react';
+import { Box, Table, Thead, Tbody, Tr, Th, Td, Input, Button, Flex, Text } from '@chakra-ui/react';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
 import { router } from '@inertiajs/react';
 import { route } from 'ziggy-js';
 
-export default function Index({ users = [] }) {
+export default function Index() {
   const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const [users, setUsers] = useState([]);
+  const [lastPage, setLastPage] = useState(1);
+  const [sort, setSort] = useState('id');
+  const [dir, setDir] = useState('asc');
 
-  const filtered = useMemo(() => {
-    const q = query.toLowerCase();
-    return users.filter(u => (
-      `${u.first_name} ${u.last_name} ${u.email}`.toLowerCase().includes(q)
-    ));
-  }, [query, users]);
+  const fetchUsers = async () => {
+    const { data } = await axios.get(route('admin.users.data'), {
+      params: { search: query, page, sort, dir }
+    });
+    setUsers(data.data);
+    setLastPage(data.last_page || 1);
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, [query, page, sort, dir]);
+
+  const handleSort = column => {
+    if (sort === column) {
+      setDir(dir === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSort(column);
+      setDir('asc');
+    }
+  };
 
   const certify = (id) => {
-    router.post(route('admin.users.certify', id));
+    router.post(route('admin.users.certify', id), {}, { onSuccess: fetchUsers });
   };
 
   const refuse = (id) => {
-    router.post(route('admin.users.refuse', id));
+    router.post(route('admin.users.refuse', id), {}, { onSuccess: fetchUsers });
   };
 
   return (
     <Box>
-      <Input placeholder="Rechercher..." mb={4} value={query} onChange={(e) => setQuery(e.target.value)} />
+      <Input
+        placeholder="Rechercher..."
+        mb={4}
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setPage(1);
+        }}
+      />
       <Table variant="striped" colorScheme="gray">
         <Thead>
           <Tr>
-            <Th>Nom</Th>
-            <Th>Email</Th>
-            <Th>Status</Th>
+            <Th cursor="pointer" onClick={() => handleSort('last_name')}>Nom {sort === 'last_name' && (dir === 'asc' ? '▲' : '▼')}</Th>
+            <Th cursor="pointer" onClick={() => handleSort('email')}>Email {sort === 'email' && (dir === 'asc' ? '▲' : '▼')}</Th>
+            <Th cursor="pointer" onClick={() => handleSort('certification_status')}>Status {sort === 'certification_status' && (dir === 'asc' ? '▲' : '▼')}</Th>
             <Th>Actions</Th>
           </Tr>
         </Thead>
         <Tbody>
-          {filtered.map(u => (
+          {users.map(u => (
             <Tr key={u.id}>
               <Td>{u.first_name} {u.last_name}</Td>
               <Td>{u.email}</Td>
@@ -47,6 +75,11 @@ export default function Index({ users = [] }) {
           ))}
         </Tbody>
       </Table>
+      <Flex mt={4} justify="space-between" align="center">
+        <Button onClick={() => setPage(p => Math.max(1, p - 1))} isDisabled={page === 1}>Précédent</Button>
+        <Text>{page} / {lastPage}</Text>
+        <Button onClick={() => setPage(p => Math.min(lastPage, p + 1))} isDisabled={page === lastPage}>Suivant</Button>
+      </Flex>
     </Box>
   );
 }

--- a/resources/js/Pages/Listing/Search.jsx
+++ b/resources/js/Pages/Listing/Search.jsx
@@ -1,20 +1,31 @@
-import { Box, Heading, SimpleGrid, Flex } from "@chakra-ui/react";
-import { useState } from "react";
-import { router } from "@inertiajs/react";
+import { Box, Heading, SimpleGrid, Flex, Button, Text } from "@chakra-ui/react";
+import { useState, useEffect } from "react";
+import axios from "axios";
 import { route } from "ziggy-js";
 import ListingCard from "@/Components/Listing/ListingCard";
 import ResponsiveFilters from "@/Components/Listing/ResponsiveFilters";
 
-export default function Search({ listings = [], filters = {} }) {
+export default function Search({ filters = {} }) {
   const [searchParams, setSearchParams] = useState(filters);
+  const [listings, setListings] = useState([]);
+  const [page, setPage] = useState(1);
+  const [lastPage, setLastPage] = useState(1);
+
+  const fetchListings = async () => {
+    const { data } = await axios.get(route('listings.index'), {
+      params: { ...searchParams, page },
+    });
+    setListings(data.data);
+    setLastPage(data.last_page || 1);
+  };
+
+  useEffect(() => {
+    fetchListings();
+  }, [searchParams, page]);
 
   const handleSearch = () => {
-    router.visit(route('listings.search'), {
-      method: 'get',
-      data: searchParams,
-      preserveScroll: true,
-      preserveState: true,
-    });
+    setPage(1);
+    fetchListings();
   };
 
   return (
@@ -31,6 +42,11 @@ export default function Search({ listings = [], filters = {} }) {
             <ListingCard key={l.id} listing={l} />
           ))}
         </SimpleGrid>
+        <Flex mt={4} justify="space-between" align="center">
+          <Button onClick={() => setPage(p => Math.max(1, p - 1))} isDisabled={page === 1}>Précédent</Button>
+          <Text>{page} / {lastPage}</Text>
+          <Button onClick={() => setPage(p => Math.min(lastPage, p + 1))} isDisabled={page === lastPage}>Suivant</Button>
+        </Flex>
       </Box>
     </Flex>
   );

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,6 +51,7 @@ Route::middleware(['auth', 'verified', EnsureIsAdmin::class])
     ->name('admin.')
     ->group(function () {
         Route::get('/users', [AdminUserController::class, 'index'])->name('users.index');
+        Route::get('/users/data', [AdminUserController::class, 'data'])->name('users.data');
         Route::post('/users/{user}/certify', [AdminUserController::class, 'certify'])->name('users.certify');
         Route::post('/users/{user}/refuse', [AdminUserController::class, 'refuse'])->name('users.refuse');
     });


### PR DESCRIPTION
## Summary
- enable dynamic pagination from the backend
- expose `/admin/users/data` endpoint
- fetch paginated data on the admin Users page
- add server-driven listing search results

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686541cbbff88330a9f956a28ab90c4f