### PR TITLE
Enhance conversation list UX

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -108,8 +108,13 @@ class PageController extends Controller
     {
         $conversations = Conversation::where('buyer_id', auth()->id())
             ->orWhere('seller_id', auth()->id())
-            ->with('listing', 'messages', 'seller', 'buyer')
-            ->get();
+            ->with('listing', 'seller', 'buyer')
+            ->withCount(['messages as unread_count' => function ($q) {
+                $q->where('sender_id', '!=', auth()->id())
+                    ->where('is_read', false);
+            }])
+            ->latest()
+            ->paginate(10);
 
         return Inertia::render('Messages/Index', [
             'conversations' => $conversations,

--- a/routes/web.php
+++ b/routes/web.php
@@ -67,6 +67,9 @@ Route::middleware(['auth', 'verified', 'certified'])->group(function () {
     Route::post('/conversations/{conversation}/block', [ConversationController::class, 'block']);
     Route::post('/conversations/{conversation}/close', [ConversationController::class, 'close']);
 
+    Route::post('/conversations/{conversation}/read', [ConversationController::class, 'markAsRead']);
+    Route::post('/conversations/{conversation}/unread', [ConversationController::class, 'markAsUnread']);
+
     Route::post('/conversations/{conversation}/messages', [MessageController::class, 'store'])->middleware('participant');
     Route::post('/messages/{message}/read', [MessageController::class, 'markAsRead']);
 


### PR DESCRIPTION
## Summary
- add pagination and unread counts to conversations API
- allow marking conversations read/unread
- limit conversations returned to 10 in messages page
- update messages page UI with load more and unread styling

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686552f2429c833085ddc2d52fb8b2ba