### PR TITLE
Enhance media step with drag-and-drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@inertiajs/inertia-react": "^0.8.1",
         "@inertiajs/react": "^2.0.13",
         "@mantine/core": "^8.1.1",
+        "@mantine/dropzone": "^8.1.1",
         "@mantine/form": "^8.1.1",
         "@mantine/hooks": "^8.1.1",
         "@mantine/notifications": "^8.1.1",


### PR DESCRIPTION
## Summary
- add `@mantine/dropzone` dependency
- improve listing creation flow with a drag-and-drop photo uploader

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657b758b0483309a330434137bc768