### PR TITLE
Enable listing gallery uploads

### DIFF
--- a/app/Http/Controllers/ListingController.php
+++ b/app/Http/Controllers/ListingController.php
@@ -17,7 +17,7 @@ class ListingController extends Controller
     public function index(Request $request)
     {
         $query = Listing::query()
-            ->with('category', 'user')
+            ->with('category', 'user', 'gallery')
             ->active()
             ->filter($request->all())
             ->withFavoriteStatus(auth()->id());
@@ -66,8 +66,8 @@ class ListingController extends Controller
             ->whereNotNull('latitude')
             ->whereNotNull('longitude')
             ->filter($request->all())
-            ->select('id', 'title', 'latitude', 'longitude', 'photos', 'address', 'price')
-            ->get();
+            ->with('gallery')
+            ->get(['id', 'title', 'latitude', 'longitude', 'address', 'price']);
 
         return response()->json([
             'data' => $listings ?? [],

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -3,12 +3,21 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Support\Facades\Storage;
 
 class File extends Model
 {
     use HasFactory;
 
     protected $fillable = ['path', 'type', 'fileable_id', 'fileable_type'];
+
+    protected $appends = ['url'];
+
+    public function url(): Attribute
+    {
+        return Attribute::get(fn () => Storage::url($this->path));
+    }
 
     public function fileable()
     {

--- a/app/Models/Listing.php
+++ b/app/Models/Listing.php
@@ -4,6 +4,7 @@ namespace App\Models;
 use App\Enums\ListingStatus;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class Listing extends Model
 {
@@ -36,6 +37,8 @@ class Listing extends Model
         'status' => ListingStatus::class,
     ];
 
+    protected $appends = ['photos'];
+
     public function user() {
         return $this->belongsTo(User::class);
     }
@@ -62,6 +65,11 @@ class Listing extends Model
 
     public function gallery() {
         return $this->morphMany(File::class, 'fileable')->where('type', 'image');
+    }
+
+    public function photos(): Attribute
+    {
+        return Attribute::get(fn () => $this->gallery->pluck('url')->toArray());
     }
 
     public function scopeFilter($query, array $filters)

--- a/resources/js/Pages/Home/Show.jsx
+++ b/resources/js/Pages/Home/Show.jsx
@@ -66,6 +66,21 @@ export default function Show({ listing, similar = [] }) {
             objectFit="cover"
             rounded="md"
           />
+          {photos.length > 1 && (
+            <SimpleGrid columns={{ base: 2, md: 3 }} spacing={2} mt={2}>
+              {photos.slice(1).map((src, i) => (
+                <Image
+                  key={i}
+                  src={src}
+                  alt={`${listing.title}-${i}`}
+                  objectFit="cover"
+                  h="100px"
+                  w="100%"
+                  rounded="md"
+                />
+              ))}
+            </SimpleGrid>
+          )}
           {isOwner && !editing && (
             <Flex justify="flex-end" mt={2} gap={2}>
               <IconButton size="sm" icon={<FaEdit />} onClick={() => setEditing(true)} aria-label="Edit" />


### PR DESCRIPTION
## Summary
- compute gallery URLs for listings and files
- eager-load gallery in listing controller
- expose gallery thumbnails on listing page

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686585bbff588330b4d5e676f700b6bd