### PR TITLE
Improve gallery display and photo paths

### DIFF
--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -16,7 +16,9 @@ class File extends Model
 
     public function url(): Attribute
     {
-        return Attribute::get(fn () => Storage::disk('public')->url($this->path));
+        // Return a relative URL so the frontend can reference files in the
+        // "public" directory without relying on the APP_URL configuration.
+        return Attribute::get(fn () => '/storage/'.ltrim($this->path, '/'));
     }
 
     public function fileable()

--- a/resources/js/Components/Listing/ListingCard.jsx
+++ b/resources/js/Components/Listing/ListingCard.jsx
@@ -9,6 +9,7 @@ import {
     IconButton,
     Button,
 } from "@chakra-ui/react";
+import Slider from "react-slick";
 import { Link } from "@inertiajs/react";
 import {FaHeart, FaRegHeart, FaStar} from "react-icons/fa";
 import {useState} from "react";
@@ -43,6 +44,15 @@ export default function ListingCard({ listing }) {
         ? listing.photos
         : JSON.parse(listing.photos || '[]');
 
+    const sliderSettings = {
+        dots: false,
+        arrows: false,
+        infinite: true,
+        speed: 400,
+        slidesToShow: 1,
+        slidesToScroll: 1,
+    };
+
     return (
         <Box
             borderRadius="lg"
@@ -53,7 +63,7 @@ export default function ListingCard({ listing }) {
             transition="transform 0.2s"
             _hover={{ transform: "scale(1.01)" }}
         >
-            <Flex overflowX="auto" gap={2}>
+            <Slider {...sliderSettings}>
                 {photos.map((photo, idx) => (
                     <Image
                         key={idx}
@@ -61,11 +71,11 @@ export default function ListingCard({ listing }) {
                         alt={`Photo ${idx + 1}`}
                         objectFit="cover"
                         height="180px"
-                        minW="300px"
+                        width="100%"
                         borderRadius="md"
                     />
                 ))}
-            </Flex>
+            </Slider>
 
             <Box p={4} pb={6}>
                 <Stack spacing={1}>

--- a/resources/js/Pages/Home/Show.jsx
+++ b/resources/js/Pages/Home/Show.jsx
@@ -1,4 +1,5 @@
 import { Box, Heading, Text, Flex, SimpleGrid, Image, Stack, IconButton, Input, Textarea, Button, Popover, PopoverTrigger, PopoverContent, Avatar } from '@chakra-ui/react';
+import Slider from 'react-slick';
 import ListingCard from '@/Components/Listing/ListingCard';
 import MapPreview from '@/Components/Map/MapPreview';
 import axios from 'axios';
@@ -9,6 +10,14 @@ import { useState } from 'react';
 export default function Show({ listing, similar = [] }) {
   const { auth } = usePage().props;
   const photos = listing.gallery?.map(g => g.url) || [];
+  const sliderSettings = {
+    dots: true,
+    arrows: false,
+    infinite: true,
+    speed: 400,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+  };
   const isOwner = auth?.user?.id === listing.user_id;
   const [editing, setEditing] = useState(false);
   const [data, setData] = useState({
@@ -58,29 +67,19 @@ export default function Show({ listing, similar = [] }) {
     <>
       <Flex direction={{ base: 'column', md: 'row' }} gap={8} align="flex-start">
         <Box flex="1">
-          <Image
-            src={photos[0] || '/placeholder.png'}
-            alt={listing.title}
-            w="full"
-            h="64"
-            objectFit="cover"
-            rounded="md"
-          />
-          {photos.length > 1 && (
-            <SimpleGrid columns={{ base: 2, md: 3 }} spacing={2} mt={2}>
-              {photos.slice(1).map((src, i) => (
-                <Image
-                  key={i}
-                  src={src}
-                  alt={`${listing.title}-${i}`}
-                  objectFit="cover"
-                  h="100px"
-                  w="100%"
-                  rounded="md"
-                />
-              ))}
-            </SimpleGrid>
-          )}
+          <Slider {...sliderSettings}>
+            {photos.map((src, i) => (
+              <Image
+                key={i}
+                src={src || '/placeholder.png'}
+                alt={`${listing.title}-${i}`}
+                objectFit="cover"
+                h="64"
+                w="full"
+                rounded="md"
+              />
+            ))}
+          </Slider>
           {isOwner && !editing && (
             <Flex justify="flex-end" mt={2} gap={2}>
               <IconButton size="sm" icon={<FaEdit />} onClick={() => setEditing(true)} aria-label="Edit" />

--- a/resources/js/app.jsx
+++ b/resources/js/app.jsx
@@ -3,6 +3,8 @@ import '../scss/index.scss';
 
 import * as React from 'react';
 import 'leaflet/dist/leaflet.css';
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
 
 import { createRoot } from 'react-dom/client';
 import { createInertiaApp } from '@inertiajs/react';


### PR DESCRIPTION
## Summary
- ensure image URLs returned from `File` model are relative to the `public` directory
- import slick carousel styles in React entrypoint
- switch listing card gallery to use a slider
- present listing page gallery using a slider as well

## Testing
- `npm test` *(fails: Missing script)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686589bb38408330a350db3067e7f35e