### PR TITLE
Fix gallery on listing details page

### DIFF
--- a/resources/js/Pages/Home/Show.jsx
+++ b/resources/js/Pages/Home/Show.jsx
@@ -9,7 +9,9 @@ import { useState } from 'react';
 
 export default function Show({ listing, similar = [] }) {
   const { auth } = usePage().props;
-  const photos = listing.gallery?.map(g => g.url) || [];
+  const photos = Array.isArray(listing.photos)
+    ? listing.photos
+    : JSON.parse(listing.photos || '[]');
   const isOwner = auth?.user?.id === listing.user_id;
   const [editing, setEditing] = useState(false);
   const [data, setData] = useState({


### PR DESCRIPTION
## Summary
- ensure photo gallery on listing detail uses same logic as listing cards

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686592fd60348330bb2cb49cabfcc184