### PR TITLE
Move FlashMessages to layout

### DIFF
--- a/resources/js/Components/Layout/LayoutWrapper.jsx
+++ b/resources/js/Components/Layout/LayoutWrapper.jsx
@@ -1,11 +1,13 @@
 import { Box } from "@chakra-ui/react";
 import Navbar from "./Navbar";
 import Footer from "./Footer";
+import FlashMessages from '../UI/FlashMessages';
 
 export default function LayoutWrapper({ children }) {
   return (
     <Box>
       <Navbar />
+      <FlashMessages />
       <Box as="main" pt="70px" px={{ base: 2, md: 4 }} pb={20} minH="80vh">
         {children}
       </Box>

--- a/resources/js/app.jsx
+++ b/resources/js/app.jsx
@@ -13,7 +13,6 @@ import { ChakraProvider } from '@chakra-ui/react';
 import { RecoilRoot } from 'recoil';
 import theme from './theme';
 import LayoutWrapper from './Components/Layout/LayoutWrapper';
-import FlashMessages from './Components/UI/FlashMessages';
 
 createInertiaApp({
   title: title => `${title} - ProprioPlus`,
@@ -27,7 +26,6 @@ createInertiaApp({
     createRoot(el).render(
       <RecoilRoot>
         <ChakraProvider theme={theme}>
-          <FlashMessages />
           <App {...props} />
         </ChakraProvider>
       </RecoilRoot>


### PR DESCRIPTION
## Summary
- remove FlashMessages from app root
- render FlashMessages inside `LayoutWrapper`

## Testing
- `php artisan test` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686598f0e4c48330aff68e58a08adfca