### PR TITLE
Fix conversation relationships and improve contact button

### DIFF
--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -14,6 +14,14 @@ class Conversation extends Model
         return $this->belongsTo(Listing::class);
     }
 
+    public function seller() {
+        return $this->belongsTo(User::class, 'seller_id');
+    }
+
+    public function buyer() {
+        return $this->belongsTo(User::class, 'buyer_id');
+    }
+
     public function messages() {
         return $this->hasMany(Message::class);
     }

--- a/resources/js/Pages/Home/Show.jsx
+++ b/resources/js/Pages/Home/Show.jsx
@@ -181,12 +181,9 @@ export default function Show({ listing, similar = [] }) {
 
           {!isOwner && (
             <Box mt={6}>
-              <button
-                onClick={handleContact}
-                className="bg-primary text-white px-4 py-2 rounded hover:bg-blue-700"
-              >
-                Contacter le vendeur
-              </button>
+              <Button width="full" colorScheme="brand" onClick={handleContact}>
+                Contacter le propriétaire
+              </Button>
             </Box>
           )}
         </Box>


### PR DESCRIPTION
## Summary
- add missing seller and buyer relationships in `Conversation` model
- restyle listing contact button using Chakra UI

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659a7515d883309a0cfb198279a045