### PR TITLE
Fix message refresh and toast duplicates

### DIFF
--- a/app/Http/Controllers/ConversationController.php
+++ b/app/Http/Controllers/ConversationController.php
@@ -107,6 +107,6 @@ class ConversationController extends Controller
             ->where('is_read', false)
             ->update(['is_read' => true]);
 
-        return response()->json($conversation->load('messages', 'seller', 'buyer'));
+        return response()->json($conversation->load(['messages.sender', 'seller', 'buyer']));
     }
 }

--- a/resources/js/Components/UI/NotificationBell.jsx
+++ b/resources/js/Components/UI/NotificationBell.jsx
@@ -36,8 +36,9 @@ export default function NotificationBell() {
 
       const currentIds = notifications.map(n => n.id);
       data.forEach(n => {
-        if (!currentIds.includes(n.id)) {
+        if (!currentIds.includes(n.id) && !toast.isActive(n.id)) {
           toast({
+            id: n.id,
             title: 'Nouveau message',
             description: n.data.content,
             status: 'info',

--- a/resources/js/Pages/Messages/Index.jsx
+++ b/resources/js/Pages/Messages/Index.jsx
@@ -64,11 +64,12 @@ export default function Index({ conversations: initial = {}, current }) {
   };
 
   useEffect(() => {
-    if (conversations.length) {
-      const first = current ? conversations.find(c => c.id == current) : conversations[0];
-      if (first) loadConversation(first);
+    if (!conversations.length) return;
+    const target = current ? conversations.find(c => c.id == current) : conversations[0];
+    if (target && target.id !== active?.id) {
+      loadConversation(target);
     }
-  }, []);
+  }, [conversations, current]);
 
   useEffect(() => {
     if (!active) return;


### PR DESCRIPTION
## Summary
- load message senders when showing a conversation
- avoid repeated notification toasts by using toast ids
- reload conversations when data changes so message history appears

## Testing
- `php artisan test` *(fails: `php: command not found`)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68659fb31b00833083e0f9363efc6647