### PR TITLE
Fix conversation refresh

### DIFF
--- a/app/Http/Controllers/ConversationController.php
+++ b/app/Http/Controllers/ConversationController.php
@@ -107,6 +107,8 @@ class ConversationController extends Controller
             ->where('is_read', false)
             ->update(['is_read' => true]);
 
-        return response()->json($conversation->load(['messages.sender', 'seller', 'buyer']));
+        $conversation = $conversation->fresh()->load(['messages.sender', 'seller', 'buyer']);
+
+        return response()->json($conversation);
     }
 }


### PR DESCRIPTION
## Summary
- refresh conversation object in controller after marking messages as read to avoid stale relations

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a4cb88208330bf3b0ea0a6d10ae3