### PR TITLE
Fix access to conversations

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -107,6 +107,9 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/favorites', [PageController::class, 'favorites'])->name('favorites.index');
     Route::post('/listings/{listing}/favorite', [ListingController::class, 'toggle'])->name('favorites.toggle');
     Route::get('/account/settings', [PageController::class, 'accountSettings'])->name('account.settings');
+});
+
+Route::middleware(['auth', 'verified', 'certified'])->group(function () {
     Route::get('/messages', [PageController::class, 'messages'])->name('messages.index');
 });
 Route::middleware(['auth'])->group(function () {


### PR DESCRIPTION
## Summary
- require verification and certification for the `/messages` page so only verified users can access conversation routes

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865af5e37b8833087383bd94281370f