### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/resources/js/Components/Admin/AdminNotificationBell.jsx
+++ b/resources/js/Components/Admin/AdminNotificationBell.jsx
@@ -43,7 +43,7 @@ export default function AdminNotificationBell() {
           </Badge>
         )}
       </MenuButton>
-      <MenuList maxW="300px">
+      <MenuList w={{ base: '100%', sm: '300px' }}>
         {notifications.length === 0 ? (
           <MenuItem>Aucune notification</MenuItem>
         ) : (

--- a/resources/js/Components/Listing/ResponsiveFilters.jsx
+++ b/resources/js/Components/Listing/ResponsiveFilters.jsx
@@ -45,7 +45,7 @@ export default function ResponsiveFilters({ searchParams, setSearchParams, onSea
   }
 
   return (
-    <Box w="300px">
+    <Box w={{ base: 'full', md: '300px' }}>
       <FilterSidebar
         searchParams={searchParams}
         setSearchParams={setSearchParams}

--- a/resources/js/Components/Map/MapPreview.jsx
+++ b/resources/js/Components/Map/MapPreview.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { MapContainer, TileLayer, Marker } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+import { useBreakpointValue } from '@chakra-ui/react';
 
 // Use a simple div icon so we don't rely on external image assets
 const customIcon = L.divIcon({
@@ -17,11 +18,13 @@ export default function MapPreview({ lat, lng }) {
     return null;
   }
 
+  const mapHeight = useBreakpointValue({ base: '200px', md: '300px' });
+
   return (
     <MapContainer
       center={[lat, lng]}
       zoom={13}
-      style={{ height: '300px', width: '100%' }}
+      style={{ height: mapHeight, width: '100%' }}
     >
       <TileLayer
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/resources/js/Components/Map/PopupMap.jsx
+++ b/resources/js/Components/Map/PopupMap.jsx
@@ -20,6 +20,7 @@ import axios from "axios";
 
 const PopupMap = ({ opened, toggle, initialPosition }) => {
     const modalSize = useBreakpointValue({ base: "xl", md: "4xl", lg: "6xl" });
+    const mapHeight = useBreakpointValue({ base: "300px", md: "500px" });
     const [coords, setCoords] = useState([]);
 
     const sliderSettings = {
@@ -79,7 +80,7 @@ const PopupMap = ({ opened, toggle, initialPosition }) => {
                     <MapContainer
                         center={[initialPosition?.lat || 48.8566, initialPosition?.lng || 2.3522]}
                         zoom={12}
-                        style={{ height: "500px", width: "100%" }}
+                        style={{ height: mapHeight, width: "100%" }}
                     >
                         <TileLayer
                             url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/resources/js/Components/UI/NotificationBell.jsx
+++ b/resources/js/Components/UI/NotificationBell.jsx
@@ -78,7 +78,7 @@ export default function NotificationBell() {
           </Badge>
         )}
       </MenuButton>
-      <MenuList maxW="300px">
+      <MenuList w={{ base: '100%', sm: '300px' }}>
         {notifications.length === 0 ? (
           <MenuItem>Aucune notification</MenuItem>
         ) : (

--- a/resources/js/Pages/Messages/Index.jsx
+++ b/resources/js/Pages/Messages/Index.jsx
@@ -150,7 +150,7 @@ export default function Index({ conversations: initial = {}, current }) {
       </VStack>
       <Box flex="1" bg="white" p={4} borderRadius="md">
         {active ? (
-          <VStack align="stretch" spacing={4} h="500px">
+          <VStack align="stretch" spacing={4} h={{ base: '400px', md: '500px' }}>
             <HStack justify="space-between">
               <Heading size="md">{active.subject || active.listing.title}</Heading>
               {partner && (


### PR DESCRIPTION
## Summary
- adjust PopupMap to use responsive height
- make MapPreview height responsive
- update notification dropdown widths for mobile
- adapt sidebar width on mobile
- set messages pane height responsive

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865af85014483308b0e69c4fbeda587