### PR TITLE
Show listing in first buyer message

### DIFF
--- a/app/Http/Controllers/ConversationController.php
+++ b/app/Http/Controllers/ConversationController.php
@@ -109,7 +109,7 @@ class ConversationController extends Controller
             ->where('is_read', false)
             ->update(['is_read' => true]);
 
-        $conversation = $conversation->fresh()->load(['messages.sender', 'seller', 'buyer']);
+        $conversation = $conversation->fresh()->load(['messages.sender', 'seller', 'buyer', 'listing']);
 
         return response()->json($conversation);
     }

--- a/resources/js/Pages/Messages/Index.jsx
+++ b/resources/js/Pages/Messages/Index.jsx
@@ -1,5 +1,6 @@
 import { Box, Heading, HStack, VStack, Text, Input, Button, Avatar, IconButton } from '@chakra-ui/react';
-import { FaCheckDouble, FaEnvelope, FaEnvelopeOpen } from 'react-icons/fa';
+import { FaCheckDouble, FaEnvelope, FaEnvelopeOpen, FaReply } from 'react-icons/fa';
+import ListingCard from '@/Components/Listing/ListingCard';
 import { usePage } from '@inertiajs/react';
 import { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
@@ -163,16 +164,38 @@ export default function Index({ conversations: initial = {}, current }) {
               )}
             </HStack>
             <VStack align="stretch" spacing={2} flex="1" overflowY="auto">
-              {messages.map(m => (
-                <Box key={m.id} alignSelf={m.sender_id === auth.user.id ? 'flex-end' : 'flex-start'} bg={m.sender_id === auth.user.id ? 'brand.200' : 'gray.100'} borderRadius="md" p={2}>
-                  <HStack>
-                    <Text>{m.content}</Text>
-                    {m.sender_id === auth.user.id && (
-                      <FaCheckDouble color={m.is_read ? 'blue' : 'gray'} />
-                    )}
-                  </HStack>
-                </Box>
-              ))}
+              {messages.map((m, idx) => {
+                const isMe = m.sender_id === auth.user.id;
+                const isFirstFromBuyer = idx === 0 && m.sender_id === active.buyer_id;
+                if (isFirstFromBuyer) {
+                  return (
+                    <Box key={m.id} alignSelf="flex-start" bg="gray.100" borderRadius="md" p={2}>
+                      <VStack align="stretch" spacing={2}>
+                        <ListingCard listing={active.listing} />
+                        <HStack fontSize="sm" color="gray.600">
+                          <FaReply />
+                          <Text>En réponse à cette annonce</Text>
+                        </HStack>
+                        <HStack>
+                          <Text>{m.content}</Text>
+                          {isMe && <FaCheckDouble color={m.is_read ? 'blue' : 'gray'} />}
+                        </HStack>
+                      </VStack>
+                    </Box>
+                  );
+                }
+
+                return (
+                  <Box key={m.id} alignSelf={isMe ? 'flex-end' : 'flex-start'} bg={isMe ? 'brand.200' : 'gray.100'} borderRadius="md" p={2}>
+                    <HStack>
+                      <Text>{m.content}</Text>
+                      {isMe && (
+                        <FaCheckDouble color={m.is_read ? 'blue' : 'gray'} />
+                      )}
+                    </HStack>
+                  </Box>
+                );
+              })}
               <div ref={messagesEndRef} />
             </VStack>
             <HStack>


### PR DESCRIPTION
## Summary
- load listing when showing conversation details
- show listing card in the first buyer message with a reply label

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68662bebe43083308c0b2c4b7592c22c