### PR TITLE
Implement identity verification review workflow

### DIFF
--- a/app/Notifications/CertificationApprovedNotification.php
+++ b/app/Notifications/CertificationApprovedNotification.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class CertificationApprovedNotification extends Notification
+{
+    use Queueable;
+
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject("Vérification d'identité approuvée")
+            ->line("Votre document d'identité a été validé par l'administrateur.")
+            ->line('Vous pouvez désormais utiliser toutes les fonctionnalités de la plateforme.');
+    }
+}

--- a/app/Notifications/CertificationRefusedNotification.php
+++ b/app/Notifications/CertificationRefusedNotification.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class CertificationRefusedNotification extends Notification
+{
+    use Queueable;
+
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject("Vérification d'identité refusée")
+            ->line("Votre demande de vérification a été refusée par l'administrateur.")
+            ->line("Vous pouvez contacter le support pour plus d'informations.");
+    }
+}

--- a/app/Notifications/CertificationReuploadNotification.php
+++ b/app/Notifications/CertificationReuploadNotification.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class CertificationReuploadNotification extends Notification
+{
+    use Queueable;
+
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject('Nouvelle preuve d\'identit\u00e9 demand\u00e9e')
+            ->line("La qualité de votre document n'a pas permis sa vérification.")
+            ->line("Merci de téléverser un document plus lisible depuis votre espace utilisateur.");
+    }
+}

--- a/resources/js/Pages/Admin/Users/Index.jsx
+++ b/resources/js/Pages/Admin/Users/Index.jsx
@@ -42,6 +42,10 @@ export default function Index() {
     router.post(route('admin.users.refuse', id), {}, { onSuccess: fetchUsers });
   };
 
+  const reupload = (id) => {
+    router.post(route('admin.users.reupload', id), {}, { onSuccess: fetchUsers });
+  };
+
   const viewDocument = (id) => {
     window.open(route('admin.users.document', id), '_blank');
   };
@@ -80,7 +84,8 @@ export default function Index() {
               </Td>
               <Td>
                 <Button size="sm" mr={2} onClick={() => certify(u.id)}>Certifier</Button>
-                <Button size="sm" variant="outline" onClick={() => refuse(u.id)}>Refuser</Button>
+                <Button size="sm" mr={2} variant="outline" onClick={() => refuse(u.id)}>Refuser</Button>
+                <Button size="sm" variant="ghost" onClick={() => reupload(u.id)}>Demander nouveau doc</Button>
               </Td>
             </Tr>
           ))}

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,6 +57,7 @@ Route::middleware(['auth', 'verified', EnsureIsAdmin::class])
         Route::get('/users/{user}/document', [AdminUserController::class, 'document'])->name('users.document');
         Route::post('/users/{user}/certify', [AdminUserController::class, 'certify'])->name('users.certify');
         Route::post('/users/{user}/refuse', [AdminUserController::class, 'refuse'])->name('users.refuse');
+        Route::post('/users/{user}/reupload', [AdminUserController::class, 'requestReupload'])->name('users.reupload');
 
         Route::get('/notifications', [AdminNotificationController::class, 'index'])->name('notifications.index');
         Route::post('/notifications/{notification}/read', [AdminNotificationController::class, 'markAsRead'])->name('notifications.read');


### PR DESCRIPTION
## Summary
- add notifications for certification approval, refusal and reupload request
- notify users from the admin panel when decisions are taken
- allow admins to ask users for new identity documents
- expose a new admin route for the reupload request
- surface the new action in the admin user list UI

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68662c8d5ec08330b51e3c286b61ea1f