### PR TITLE
Improve search layout

### DIFF
--- a/resources/js/Components/Listing/FilterSidebar.jsx
+++ b/resources/js/Components/Listing/FilterSidebar.jsx
@@ -41,7 +41,7 @@ export default function FilterSidebar({ searchParams, setSearchParams, onSearch 
   };
 
   return (
-    <VStack align="stretch" spacing={4} position="sticky" top="100px">
+    <VStack align="stretch" spacing={4} position="sticky" top="20px">
       <Box>
         <Text mb={2}>Prix (€)</Text>
         <RangeSlider

--- a/resources/js/Components/Listing/ListingCard.jsx
+++ b/resources/js/Components/Listing/ListingCard.jsx
@@ -54,7 +54,7 @@ export default function ListingCard({ listing }) {
     };
 
     return (
-        <Box
+        <Flex
             borderWidth="1px"
             borderRadius="lg"
             overflow="hidden"
@@ -63,10 +63,9 @@ export default function ListingCard({ listing }) {
             position="relative"
             transition="transform 0.2s"
             _hover={{ boxShadow: 'lg', transform: 'translateY(-2px)' }}
-            display="flex"
-            flexDirection="column"
+            direction={{ base: 'column', md: 'row' }}
         >
-            <Box position="relative">
+            <Box position="relative" w={{ base: '100%', md: '40%' }}>
                 <Slider {...sliderSettings}>
                     {photos.map((photo, idx) => (
                         <Image
@@ -82,22 +81,24 @@ export default function ListingCard({ listing }) {
                 <FavoriteButton listingId={listing.id} isFavorited={listing.is_favorited} />
             </Box>
 
-            <Stack spacing={3} p={4} flex="1">
-                <Text fontSize="xl" fontWeight="bold">{listing.title}</Text>
-                <Text fontSize="md" color="gray.600">{listing.city}, {listing.postal_code}</Text>
-                <Text fontSize="lg" fontWeight="bold">{listing.price} €<Text as="span" fontWeight="normal" color="gray.500"> / nuit</Text></Text>
-                <Text fontSize="sm" color="gray.600">Surface : {listing.surface} m²</Text>
-                <Text fontSize="sm" color="gray.600">Pièces : {listing.rooms}, Chambres : {listing.bedrooms}, Sdb : {listing.bathrooms}</Text>
-                <HStack spacing={3} pt={2}>
-                    {listing.has_terrace && <Text fontSize="sm" color="gray.600">Terrasse</Text>}
-                    {listing.has_parking && <Text fontSize="sm" color="gray.600">Parking</Text>}
-                </HStack>
-            </Stack>
-            <Flex px={4} pb={4} justify="flex-end">
-                <Button as={Link} href={`/listings/${listing.id}`} colorScheme="brand" size="sm">
-                    Voir l'annonce
-                </Button>
+            <Flex direction="column" flex="1">
+                <Stack spacing={3} p={4} flex="1">
+                    <Text fontSize="xl" fontWeight="bold">{listing.title}</Text>
+                    <Text fontSize="md" color="gray.600">{listing.city}, {listing.postal_code}</Text>
+                    <Text fontSize="lg" fontWeight="bold">{listing.price} €<Text as="span" fontWeight="normal" color="gray.500"> / nuit</Text></Text>
+                    <Text fontSize="sm" color="gray.600">Surface : {listing.surface} m²</Text>
+                    <Text fontSize="sm" color="gray.600">Pièces : {listing.rooms}, Chambres : {listing.bedrooms}, Sdb : {listing.bathrooms}</Text>
+                    <HStack spacing={3} pt={2}>
+                        {listing.has_terrace && <Text fontSize="sm" color="gray.600">Terrasse</Text>}
+                        {listing.has_parking && <Text fontSize="sm" color="gray.600">Parking</Text>}
+                    </HStack>
+                </Stack>
+                <Flex px={4} pb={4} justify="flex-end">
+                    <Button as={Link} href={`/listings/${listing.id}`} colorScheme="brand" size="sm">
+                        Voir l'annonce
+                    </Button>
+                </Flex>
             </Flex>
-        </Box>
+        </Flex>
     );
 }

--- a/resources/js/Pages/Listing/Search.jsx
+++ b/resources/js/Pages/Listing/Search.jsx
@@ -1,4 +1,13 @@
-import { Box, Heading, SimpleGrid, Flex, Button, Text } from "@chakra-ui/react";
+import {
+  Box,
+  Heading,
+  SimpleGrid,
+  Flex,
+  IconButton,
+  Text,
+  Divider,
+} from "@chakra-ui/react";
+import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
 import { useState, useEffect } from "react";
 import axios from "axios";
 import { route } from "ziggy-js";
@@ -35,18 +44,40 @@ export default function Search({ filters = {} }) {
         setSearchParams={setSearchParams}
         onSearch={handleSearch}
       />
+
+      <Divider orientation="vertical" display={{ base: 'none', md: 'block' }} mx={2} />
+
       <Box flex="1">
-        <Heading size="lg" mb={6}>Résultats de recherche</Heading>
-        <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={6}>
+        <Heading size="lg" mb={6}>
+          Résultats de recherche
+        </Heading>
+        <SimpleGrid columns={1} spacing={6}>
           {listings.map((l) => (
             <ListingCard key={l.id} listing={l} />
           ))}
         </SimpleGrid>
-        <Flex mt={4} justify="space-between" align="center">
-          <Button onClick={() => setPage(p => Math.max(1, p - 1))} isDisabled={page === 1}>Précédent</Button>
-          <Text>{page} / {lastPage}</Text>
-          <Button onClick={() => setPage(p => Math.min(lastPage, p + 1))} isDisabled={page === lastPage}>Suivant</Button>
-        </Flex>
+
+        {lastPage > 1 && (
+          <Flex mt={8} justify="center" align="center" gap={4}>
+            <IconButton
+              icon={<FaChevronLeft />}
+              isRound
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              isDisabled={page === 1}
+              aria-label="Page précédente"
+            />
+            <Text>
+              {page} / {lastPage}
+            </Text>
+            <IconButton
+              icon={<FaChevronRight />}
+              isRound
+              onClick={() => setPage((p) => Math.min(lastPage, p + 1))}
+              isDisabled={page === lastPage}
+              aria-label="Page suivante"
+            />
+          </Flex>
+        )}
       </Box>
     </Flex>
   );


### PR DESCRIPTION
## Summary
- keep filter sidebar sticky while scrolling
- update listing cards to horizontal layout
- show listings in single column
- add divider and improved pagination

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68662d716bf48330a3ad79a0daadfcc8