### PR TITLE
Improve profile and account pages

### DIFF
--- a/resources/js/Pages/Account/Profile.jsx
+++ b/resources/js/Pages/Account/Profile.jsx
@@ -1,6 +1,17 @@
 import React from 'react';
 import { usePage, Link } from '@inertiajs/react';
-import { Box, Flex, Avatar, Heading, Text, Stack, Button } from '@chakra-ui/react';
+import {
+  Box,
+  Flex,
+  Avatar,
+  Heading,
+  Text,
+  Stack,
+  Button,
+  Icon,
+  HStack,
+} from '@chakra-ui/react';
+import { EmailIcon, PhoneIcon, CalendarIcon } from '@chakra-ui/icons';
 
 export default function Profile({ user }) {
   const pageUser = user || usePage().props.auth.user;
@@ -12,23 +23,44 @@ export default function Profile({ user }) {
   const fullName = `${pageUser.first_name} ${pageUser.last_name}`;
 
   return (
-    <Flex justify="center" p={4}>
-      <Box bg="white" p={6} rounded="md" shadow="sm" w="full" maxW="lg">
-        <Stack direction={{ base: 'column', md: 'row' }} spacing={6} align="center">
-          <Avatar name={fullName} size="xl" />
+    <Flex justify="center" p={{ base: 4, md: 8 }}>
+      <Box
+        bg="white"
+        p={8}
+        rounded="xl"
+        shadow="lg"
+        w="full"
+        maxW="2xl"
+        bgGradient="linear(to-br, white, gray.50)"
+      >
+        <Stack direction={{ base: 'column', md: 'row' }} spacing={8} align="center">
+          <Avatar name={fullName} size="2xl" />
           <Box flex="1">
-            <Heading size="md" mb={1}>{fullName}</Heading>
-            <Text color="gray.600">{pageUser.email}</Text>
-            {pageUser.phone && (
-              <Text color="gray.600">{pageUser.phone}</Text>
-            )}
-            <Text mt={2} fontSize="sm" color="gray.500">
-              Membre depuis {new Date(pageUser.created_at).toLocaleDateString()}
-            </Text>
+            <Heading size="lg" mb={4} fontWeight="medium">
+              {fullName}
+            </Heading>
+            <Stack spacing={2} fontSize="md" color="gray.600">
+              <HStack>
+                <Icon as={EmailIcon} />
+                <Text>{pageUser.email}</Text>
+              </HStack>
+              {pageUser.phone && (
+                <HStack>
+                  <Icon as={PhoneIcon} />
+                  <Text>{pageUser.phone}</Text>
+                </HStack>
+              )}
+              <HStack>
+                <Icon as={CalendarIcon} />
+                <Text>
+                  Membre depuis {new Date(pageUser.created_at).toLocaleDateString()}
+                </Text>
+              </HStack>
+            </Stack>
           </Box>
         </Stack>
-        <Flex mt={6} justify={{ base: 'center', md: 'flex-end' }}>
-          <Button as={Link} href="/account/settings" width={{ base: 'full', md: 'auto' }}>
+        <Flex mt={8} justify={{ base: 'center', md: 'flex-end' }}>
+          <Button as={Link} href="/account/settings" variant="fancy" px={8}>
             Modifier mon profil
           </Button>
         </Flex>

--- a/resources/js/Pages/Account/Settings.jsx
+++ b/resources/js/Pages/Account/Settings.jsx
@@ -1,21 +1,66 @@
-import React from 'react';
-import { Box, Heading, Tabs, TabList, TabPanels, Tab, TabPanel } from '@chakra-ui/react';
-import { usePage } from '@inertiajs/react';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Box,
+  Heading,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  Icon,
+  Button,
+  Flex,
+} from '@chakra-ui/react';
+import { InfoOutlineIcon, LockIcon, ArrowBackIcon } from '@chakra-ui/icons';
+import { Link, usePage } from '@inertiajs/react';
 import PersonalInfoForm from '@/Components/Account/PersonalInfoForm';
 import PasswordForm from '@/Components/Account/PasswordForm';
 
 export default function Settings({ user }) {
   const pageUser = user || usePage().props.user;
+  const [index, setIndex] = useState(0);
+  const panelsRef = useRef(null);
+
+  useEffect(() => {
+    const hash = window.location.hash;
+    if (hash === '#password') {
+      setIndex(1);
+    }
+  }, []);
+
+  const handleChange = (i) => {
+    setIndex(i);
+    const hash = i === 0 ? '#info' : '#password';
+    window.history.replaceState(null, '', hash);
+    panelsRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
 
   return (
     <Box p={8}>
-      <Heading size="lg" mb={6}>Paramètres du compte</Heading>
-      <Tabs orientation="vertical" variant="line" isLazy display={{ md: 'flex' }}>
-        <TabList minW="200px" borderRight="1px" borderColor="gray.200">
-          <Tab>Informations personnelles</Tab>
-          <Tab>Mot de passe</Tab>
+      <Flex mb={6} align="center">
+        <Button as={Link} href="/profile" leftIcon={<ArrowBackIcon />} variant="ghost" mr={4}>
+          Retour au profil
+        </Button>
+        <Heading size="lg">Paramètres du compte</Heading>
+      </Flex>
+      <Tabs
+        orientation="vertical"
+        variant="enclosed"
+        colorScheme="brand"
+        isLazy
+        index={index}
+        onChange={handleChange}
+        display={{ md: 'flex' }}
+      >
+        <TabList minW="240px" borderRightWidth={{ md: '1px' }} borderColor="gray.200">
+          <Tab>
+            <Icon as={InfoOutlineIcon} mr={2} /> Informations personnelles
+          </Tab>
+          <Tab>
+            <Icon as={LockIcon} mr={2} /> Mot de passe
+          </Tab>
         </TabList>
-        <TabPanels flex="1" pl={{ md: 6 }} mt={{ base: 4, md: 0 }}>
+        <TabPanels ref={panelsRef} flex="1" pl={{ md: 6 }} mt={{ base: 4, md: 0 }}>
           <TabPanel px={0}>
             <PersonalInfoForm user={pageUser} />
           </TabPanel>


### PR DESCRIPTION
## Summary
- redesign profile page
- enhance account settings page with icons, back navigation and better tab handling

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68662f1986608330b093e992bdd867a3