### PR TITLE
Implement listing scoring for homepage

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -10,14 +10,15 @@ class HomeController extends Controller
 {
     public function index()
     {
-        $featured = Listing::with('gallery')
+        $bestMatches = Listing::with('gallery')
             ->active()
-            ->latest()
+            ->withCount(['conversations', 'favoritedBy as favorites_count'])
+            ->orderByRaw('(conversations_count * 2 + favorites_count) desc')
             ->take(6)
             ->get();
 
         return Inertia::render('Home/Index', [
-            'featured' => $featured
+            'bestMatches' => $bestMatches
         ]);
     }
 }

--- a/app/Http/Controllers/ListingController.php
+++ b/app/Http/Controllers/ListingController.php
@@ -32,7 +32,12 @@ class ListingController extends Controller
 
         $sort = $request->input('sort', 'created_at');
         $dir = $request->input('dir', 'desc');
-        $query->orderBy($sort, $dir);
+        if ($sort === 'score') {
+            $query->withCount(['conversations', 'favoritedBy as favorites_count'])
+                ->orderByRaw('(conversations_count * 2 + favorites_count) ' . $dir);
+        } else {
+            $query->orderBy($sort, $dir);
+        }
 
         $perPage = (int) $request->input('per_page', 10);
 

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -12,7 +12,16 @@ class PageController extends Controller
 {
     public function home()
     {
-        return Inertia::render('Home/Index');
+        $bestMatches = Listing::with('gallery')
+            ->active()
+            ->withCount(['conversations', 'favoritedBy as favorites_count'])
+            ->orderByRaw('(conversations_count * 2 + favorites_count) desc')
+            ->take(6)
+            ->get();
+
+        return Inertia::render('Home/Index', [
+            'bestMatches' => $bestMatches,
+        ]);
     }
 
     public function search(Request $request)

--- a/app/Models/Listing.php
+++ b/app/Models/Listing.php
@@ -37,7 +37,12 @@ class Listing extends Model
         'status' => ListingStatus::class,
     ];
 
-    protected $appends = ['photos'];
+    protected $appends = ['photos', 'score'];
+
+    protected $withCount = [
+        'conversations',
+        'favoritedBy as favorites_count',
+    ];
 
     public function user() {
         return $this->belongsTo(User::class);
@@ -70,6 +75,15 @@ class Listing extends Model
     public function photos(): Attribute
     {
         return Attribute::get(fn () => $this->gallery->pluck('url')->toArray());
+    }
+
+    public function score(): Attribute
+    {
+        return Attribute::get(function () {
+            $favorites = $this->favorites_count ?? $this->favoritedBy()->count();
+            $conversations = $this->conversations_count ?? $this->conversations()->count();
+            return $conversations * 2 + $favorites;
+        });
     }
 
     public function scopeFilter($query, array $filters)

--- a/resources/js/Pages/Home/Index.jsx
+++ b/resources/js/Pages/Home/Index.jsx
@@ -5,13 +5,15 @@ import {
   Text,
   Button,
   Image,
+  SimpleGrid,
   useBreakpointValue
 } from "@chakra-ui/react";
 import SearchBar from "@/Components/Listing/SearchBar.jsx";
 import FeatureSection from "@/Components/Listing/FeatureSection";
 import CreateListingCTA from "@/Components/Home/CreateListingCTA";
+import ListingCard from "@/Components/Listing/ListingCard";
 
-export default function Home() {
+export default function Home({ bestMatches = [] }) {
   const heroHeight = useBreakpointValue({ base: "240px", md: "320px", lg: "400px" });
 
   return (
@@ -38,6 +40,19 @@ export default function Home() {
 
         <FeatureSection />
         <CreateListingCTA />
+
+        {bestMatches.length > 0 && (
+            <Box mt={10} pb={10}>
+                <Heading size="lg" mb={6} textAlign="center">
+                    Annonces populaires
+                </Heading>
+                <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={6}>
+                    {bestMatches.map((l) => (
+                        <ListingCard key={l.id} listing={l} />
+                    ))}
+                </SimpleGrid>
+            </Box>
+        )}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- rank listings by popularity using conversations and favorites
- expose `score` attribute via model accessor
- allow sorting by score in listing index
- show popular listings on homepage

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686637fe0a588330b4dced8aa35e694c