### PR TITLE
Add customizable rich text editor for admin pages

### DIFF
--- a/resources/js/Components/Admin/RichTextEditor.jsx
+++ b/resources/js/Components/Admin/RichTextEditor.jsx
@@ -1,0 +1,47 @@
+import { Box, Flex, IconButton, Select } from '@chakra-ui/react';
+import { FaBold, FaItalic, FaUnderline } from 'react-icons/fa';
+import { useRef, useEffect } from 'react';
+
+export default function RichTextEditor({ value = '', onChange }) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (ref.current && value !== ref.current.innerHTML) {
+      ref.current.innerHTML = value;
+    }
+  }, [value]);
+
+  const exec = (command, arg = null) => {
+    ref.current.focus();
+    document.execCommand(command, false, arg);
+    onChange && onChange(ref.current.innerHTML);
+  };
+
+  const handleInput = () => {
+    onChange && onChange(ref.current.innerHTML);
+  };
+
+  return (
+    <Box border="1px" borderColor="gray.300" borderRadius="md">
+      <Flex bg="gray.100" p={2} gap={1} wrap="wrap">
+        <IconButton icon={<FaBold />} size="sm" aria-label="bold" onClick={() => exec('bold')} />
+        <IconButton icon={<FaItalic />} size="sm" aria-label="italic" onClick={() => exec('italic')} />
+        <IconButton icon={<FaUnderline />} size="sm" aria-label="underline" onClick={() => exec('underline')} />
+        <Select width="auto" size="sm" onChange={(e) => exec('fontSize', e.target.value)}>
+          <option value="3">Normal</option>
+          <option value="4">Large</option>
+          <option value="5">Larger</option>
+          <option value="6">Huge</option>
+        </Select>
+        <input type="color" onChange={(e) => exec('foreColor', e.target.value)} style={{ width: 28, height: 28, border: 'none' }} />
+      </Flex>
+      <Box
+        ref={ref}
+        contentEditable
+        onInput={handleInput}
+        p={2}
+        minH="120px"
+      />
+    </Box>
+  );
+}

--- a/resources/js/Components/Admin/SectionEditor.jsx
+++ b/resources/js/Components/Admin/SectionEditor.jsx
@@ -1,0 +1,27 @@
+import { Box, FormControl, FormLabel, IconButton, Input, Flex } from '@chakra-ui/react';
+import { CloseIcon } from '@chakra-ui/icons';
+import RichTextEditor from './RichTextEditor';
+
+export default function SectionEditor({ section, onChange, onRemove }) {
+  const update = (field, value) => {
+    onChange && onChange({ ...section, [field]: value });
+  };
+
+  return (
+    <Box border="1px" borderColor="gray.200" borderRadius="md" p={4} mb={4} bg="white">
+      <Flex justify="flex-end">
+        {onRemove && (
+          <IconButton size="sm" icon={<CloseIcon />} aria-label="remove" onClick={onRemove} />
+        )}
+      </Flex>
+      <FormControl mb={3}>
+        <FormLabel>Image (URL)</FormLabel>
+        <Input value={section.image || ''} onChange={(e) => update('image', e.target.value)} />
+      </FormControl>
+      <FormControl>
+        <FormLabel>Texte</FormLabel>
+        <RichTextEditor value={section.text || ''} onChange={(val) => update('text', val)} />
+      </FormControl>
+    </Box>
+  );
+}

--- a/resources/js/Pages/Admin/Pages/Edit.jsx
+++ b/resources/js/Pages/Admin/Pages/Edit.jsx
@@ -1,39 +1,64 @@
-import { Box, FormControl, FormLabel, Input, Textarea, Button } from '@chakra-ui/react';
+import { Box, FormControl, FormLabel, Input, Button, Heading } from '@chakra-ui/react';
 import { useForm } from '@inertiajs/react';
+import { useState } from 'react';
 import AdminLayout from '@/Components/Admin/AdminLayout';
+import SectionEditor from '@/Components/Admin/SectionEditor';
 import { route } from 'ziggy-js';
 
 export default function Edit({ page }) {
   const { data, setData, post, processing } = useForm({
     title: page.title || '',
-    sections: JSON.stringify(page.sections || [], null, 2),
     images: null,
   });
 
-  const submit = e => {
+  const [sections, setSections] = useState(page.sections || []);
+
+  const updateSection = (index, updated) => {
+    setSections((secs) => secs.map((s, i) => (i === index ? updated : s)));
+  };
+
+  const addSection = () => {
+    setSections((secs) => [
+      ...secs,
+      { id: Date.now().toString(), text: '', image: '' },
+    ]);
+  };
+
+  const removeSection = (index) => {
+    setSections((secs) => secs.filter((_, i) => i !== index));
+  };
+
+  const submit = (e) => {
     e.preventDefault();
+    setData('sections', JSON.stringify(sections));
     post(route('admin.pages.update', page.id), { forceFormData: true });
   };
 
   return (
-    <Box as="form" onSubmit={submit} maxW="2xl" mx="auto">
+    <Box as="form" onSubmit={submit} maxW="3xl" mx="auto">
+      <Heading size="lg" mb={6}>Modifier la page</Heading>
       <FormControl mb={4}>
         <FormLabel>Titre</FormLabel>
-        <Input value={data.title} onChange={e => setData('title', e.target.value)} />
+        <Input value={data.title} onChange={(e) => setData('title', e.target.value)} />
       </FormControl>
-      <FormControl mb={4}>
-        <FormLabel>Sections (JSON)</FormLabel>
-        <Textarea
-          value={data.sections}
-          onChange={e => setData('sections', e.target.value)}
-          rows={10}
+      {sections.map((section, index) => (
+        <SectionEditor
+          key={section.id}
+          section={section}
+          onChange={(sec) => updateSection(index, sec)}
+          onRemove={() => removeSection(index)}
         />
-      </FormControl>
+      ))}
+      <Button size="sm" mb={4} onClick={addSection} variant="outline">
+        Ajouter une section
+      </Button>
       <FormControl mb={4}>
         <FormLabel>Galerie</FormLabel>
-        <Input type="file" multiple onChange={e => setData('images', e.target.files)} />
+        <Input type="file" multiple onChange={(e) => setData('images', e.target.files)} />
       </FormControl>
-      <Button type="submit" colorScheme="brand" isLoading={processing}>Enregistrer</Button>
+      <Button type="submit" colorScheme="brand" isLoading={processing}>
+        Enregistrer
+      </Button>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add generic `RichTextEditor` component with font/formatting tools
- create `SectionEditor` wrapper for page sections
- revamp admin page editor to use the new components and cleaner layout

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6866752f73e48330a6568f322475b2aa