### PR TITLE
Add mode toggle and fix ListingCard imports

### DIFF
--- a/resources/js/Components/Layout/Navbar.jsx
+++ b/resources/js/Components/Layout/Navbar.jsx
@@ -16,16 +16,20 @@ import {
     Image
 } from "@chakra-ui/react";
 import { HamburgerIcon } from "@chakra-ui/icons";
+import { useRecoilState } from 'recoil';
+import modeAtom from '@/state/modeAtom';
 import NotificationBell from "../UI/NotificationBell";
 import { Link, usePage } from "@inertiajs/react";
 import { route } from "ziggy-js";
 
 export default function Navbar() {
     const { auth } = usePage().props;
+    const [mode, setMode] = useRecoilState(modeAtom);
     const { isOpen, onOpen, onClose } = useDisclosure();
     const isMobile = useBreakpointValue({ base: true, md: false });
 
     const [isScrolled, setIsScrolled] = useState(false);
+    const toggleMode = () => setMode(mode === 'buyer' ? 'seller' : 'buyer');
 
     // 🔁 Scroll effect to reduce height and change background
     useEffect(() => {
@@ -78,6 +82,9 @@ export default function Navbar() {
                 {auth.isAdmin && (
                     <Button as={Link} href="/admin/users" mr={4}>Admin</Button>
                 )}
+                <Button onClick={toggleMode} mr={4} variant="ghost">
+                    {mode === 'buyer' ? 'Mode vendeur' : 'Mode acheteur'}
+                </Button>
                 <NotificationBell />
                 <Menu>
                     <MenuButton as={Button} variant="ghost" rightIcon={<HamburgerIcon />}>
@@ -100,6 +107,9 @@ export default function Navbar() {
                             <MenuItem as={Link} href="/about-us">À propos</MenuItem>
                             <MenuItem as={Link} href="/code-of-conduct">Code de conduite</MenuItem>
                             <MenuItem as={Link} href="/reglements">Règlements</MenuItem>
+                            <MenuItem onClick={toggleMode}>
+                                {mode === 'buyer' ? 'Mode vendeur' : 'Mode acheteur'}
+                            </MenuItem>
                             <MenuItem as={Link} href="/login">Se connecter</MenuItem>
                             <MenuItem as={Link} href="/register">S’inscrire</MenuItem>
                         </MenuList>

--- a/resources/js/Components/Listing/ListingCard.jsx
+++ b/resources/js/Components/Listing/ListingCard.jsx
@@ -13,6 +13,7 @@ import Slider from "react-slick";
 import { Link } from "@inertiajs/react";
 import {FaHeart, FaRegHeart, FaStar} from "react-icons/fa";
 import {useState} from "react";
+import axios from 'axios';
 function FavoriteButton({ listingId, isFavorited, onToggle }) {
     const [favorited, setFavorited] = useState(isFavorited);
 

--- a/resources/js/state/modeAtom.js
+++ b/resources/js/state/modeAtom.js
@@ -1,0 +1,24 @@
+import { atom } from 'recoil';
+
+const getInitialMode = () => {
+  if (typeof localStorage !== 'undefined') {
+    return localStorage.getItem('mode') || 'buyer';
+  }
+  return 'buyer';
+};
+
+const modeAtom = atom({
+  key: 'mode',
+  default: getInitialMode(),
+  effects_UNSTABLE: [
+    ({ onSet }) => {
+      onSet(newMode => {
+        if (typeof localStorage !== 'undefined') {
+          localStorage.setItem('mode', newMode);
+        }
+      });
+    }
+  ]
+});
+
+export default modeAtom;


### PR DESCRIPTION
## Summary
- add global `modeAtom` recoil state to persist buyer/seller mode
- add toggle button in `Navbar` for switching between modes
- show the mode toggle on mobile menu as well
- fix missing axios import in `ListingCard`

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a6ec695483308e93688ea581922f