### PR TITLE
Add dynamic listing similarity suggestions

### DIFF
--- a/app/Http/Controllers/ListingController.php
+++ b/app/Http/Controllers/ListingController.php
@@ -85,12 +85,8 @@ class ListingController extends Controller
             ->withFavoriteStatus(auth()->id())
             ->findOrFail($listing->id);
 
-        $similar = Listing::where('category_id', $listing->category_id)
-            ->where('id', '!=', $listing->id)
-            ->where('city', $listing->city)
-            ->active()
-            ->withFavoriteStatus(auth()->id())
-            ->limit(4)->get();
+        $listing->append('similar_listings');
+        $similar = $listing->similar_listings;
 
         return response()->json([
             'listing' => $listing,

--- a/tests/Unit/ListingSimilarityTest.php
+++ b/tests/Unit/ListingSimilarityTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Listing;
+use PHPUnit\Framework\TestCase;
+
+class ListingSimilarityTest extends TestCase
+{
+    public function test_similarity_with_more_attributes_gives_higher_score(): void
+    {
+        $a = new Listing([
+            'category_id' => 1,
+            'city' => 'Paris',
+            'price' => 100000,
+            'rooms' => 3,
+            'bedrooms' => 2,
+            'bathrooms' => 1,
+            'has_terrace' => true,
+        ]);
+
+        $b = new Listing([
+            'category_id' => 1,
+            'city' => 'Paris',
+            'price' => 105000,
+            'rooms' => 3,
+            'bedrooms' => 2,
+            'bathrooms' => 1,
+            'has_terrace' => true,
+        ]);
+
+        $c = new Listing([
+            'category_id' => 2,
+            'city' => 'Lyon',
+            'price' => 300000,
+            'rooms' => 1,
+            'bedrooms' => 1,
+            'bathrooms' => 1,
+            'has_terrace' => false,
+        ]);
+
+        $scoreSimilar = $a->similarityWith($b);
+        $scoreDifferent = $a->similarityWith($c);
+
+        $this->assertTrue($scoreSimilar > $scoreDifferent);
+    }
+}


### PR DESCRIPTION
## Summary
- expand Listing model with `similar_listings` attribute
- compute similarity score based on several property attributes
- expose similar listings via ListingController
- test similarity calculation

## Testing
- `php artisan test` *(fails: `bash: php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6866a91485048330a8fb79aeb47d2f4d