### PR TITLE
Add meeting feature to conversations

### DIFF
--- a/app/Http/Controllers/ConversationController.php
+++ b/app/Http/Controllers/ConversationController.php
@@ -109,7 +109,7 @@ class ConversationController extends Controller
             ->where('is_read', false)
             ->update(['is_read' => true]);
 
-        $conversation = $conversation->fresh()->load(['messages.sender', 'seller', 'buyer', 'listing']);
+        $conversation = $conversation->fresh()->load(['messages.sender', 'seller', 'buyer', 'listing', 'meetings']);
 
         return response()->json($conversation);
     }

--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -1,0 +1,72 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Conversation;
+use App\Models\Meeting;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Notifications\MeetingProposalNotification;
+use App\Models\Message;
+use App\Notifications\NewMessageNotification;
+use App\Models\User;
+
+class MeetingController extends Controller
+{
+    public function store(Request $request, Conversation $conversation)
+    {
+        $this->authorize('view', $conversation);
+        if (Auth::id() !== $conversation->seller_id) {
+            return response()->json(['message' => 'Seul le vendeur peut proposer un rendez-vous'], 403);
+        }
+
+        $data = $request->validate([
+            'scheduled_at' => 'required|date',
+            'type' => 'required|in:meeting,visit',
+            'agenda' => 'nullable|string',
+        ]);
+
+        $meeting = $conversation->meetings()->create([
+            'scheduled_at' => $data['scheduled_at'],
+            'type' => $data['type'],
+            'agenda' => $data['agenda'] ?? null,
+            'status' => 'pending',
+        ]);
+
+        $content = 'Proposition de ' . ($data['type'] === 'visit' ? 'visite' : 'rendez-vous') .
+            ' le ' . $meeting->scheduled_at->format('d/m/Y H:i');
+        if ($meeting->agenda) {
+            $content .= ' - ' . $meeting->agenda;
+        }
+
+        $message = Message::create([
+            'conversation_id' => $conversation->id,
+            'sender_id' => Auth::id(),
+            'content' => $content,
+            'is_read' => false,
+        ]);
+
+        if ($recipient = User::find($conversation->buyer_id)) {
+            $recipient->notify(new MeetingProposalNotification($meeting));
+            $recipient->notify(new NewMessageNotification($message));
+        }
+
+        return response()->json($meeting);
+    }
+
+    public function update(Request $request, Meeting $meeting)
+    {
+        $conversation = $meeting->conversation;
+        $this->authorize('view', $conversation);
+        if (Auth::id() !== $conversation->buyer_id) {
+            return response()->json(['message' => 'Seul l\'acheteur peut répondre'], 403);
+        }
+
+        $data = $request->validate([
+            'status' => 'required|in:accepted,declined',
+        ]);
+
+        $meeting->update(['status' => $data['status']]);
+
+        return response()->json($meeting);
+    }
+}

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -2,6 +2,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Meeting;
 use Illuminate\Database\Eloquent\Attributes\UsePolicy;
 use App\Policies\ConversationPolicy;
 
@@ -24,5 +25,9 @@ class Conversation extends Model
 
     public function messages() {
         return $this->hasMany(Message::class)->orderBy('created_at');
+    }
+
+    public function meetings() {
+        return $this->hasMany(Meeting::class);
     }
 }

--- a/app/Models/Meeting.php
+++ b/app/Models/Meeting.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Meeting extends Model
+{
+    protected $fillable = [
+        'conversation_id',
+        'scheduled_at',
+        'type',
+        'agenda',
+        'status',
+    ];
+
+    protected $casts = [
+        'scheduled_at' => 'datetime',
+    ];
+
+    public function conversation()
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+}

--- a/app/Notifications/MeetingProposalNotification.php
+++ b/app/Notifications/MeetingProposalNotification.php
@@ -1,0 +1,32 @@
+<?php
+namespace App\Notifications;
+
+use App\Models\Meeting;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class MeetingProposalNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(public Meeting $meeting)
+    {
+    }
+
+    public function via($notifiable)
+    {
+        return ['database'];
+    }
+
+    public function toDatabase($notifiable)
+    {
+        return [
+            'meeting_id' => $this->meeting->id,
+            'conversation_id' => $this->meeting->conversation_id,
+            'scheduled_at' => $this->meeting->scheduled_at,
+            'type' => $this->meeting->type,
+            'agenda' => $this->meeting->agenda,
+            'sender_id' => $this->meeting->conversation->seller_id,
+        ];
+    }
+}

--- a/database/migrations/2025_06_22_000006_create_meetings_table.php
+++ b/database/migrations/2025_06_22_000006_create_meetings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('meetings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('conversation_id')->constrained()->onDelete('cascade');
+            $table->dateTime('scheduled_at');
+            $table->string('type')->default('meeting');
+            $table->text('agenda')->nullable();
+            $table->string('status')->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('meetings');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\ConversationController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\ListingController;
 use App\Http\Controllers\MessageController;
+use App\Http\Controllers\MeetingController;
 use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\PageController;
 use App\Http\Controllers\ReportController;
@@ -91,6 +92,8 @@ Route::middleware(['auth', 'verified', 'certified'])->group(function () {
     Route::post('/conversations/{conversation}/unread', [ConversationController::class, 'markAsUnread']);
 
     Route::post('/conversations/{conversation}/messages', [MessageController::class, 'store'])->middleware('participant');
+    Route::post('/conversations/{conversation}/meetings', [MeetingController::class, 'store'])->middleware('participant');
+    Route::post('/meetings/{meeting}/status', [MeetingController::class, 'update'])->middleware('participant');
     Route::post('/messages/{message}/read', [MessageController::class, 'markAsRead']);
 
     Route::get('/notifications', [NotificationController::class, 'index']);


### PR DESCRIPTION
## Summary
- add Meeting model and migration
- allow sellers to propose meetings or visits within conversations
- notify buyers of meeting proposals
- expose meeting routes and load meetings in conversation responses

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a9c381ec8330ad6195223e1b8ce1