### PR TITLE
Fix accessor and route syntax

### DIFF
--- a/app/Models/Listing.php
+++ b/app/Models/Listing.php
@@ -251,9 +251,9 @@ class Listing extends Model
         return $listings->sortByDesc('similarity')->take($limit)->values();
     }
 
-    public function similarListingsAttribute(): Attribute
+    public function getSimilarListingsAttribute()
     {
-        return Attribute::get(fn () => $this->similarListings());
+        return $this->similarListings();
     }
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -56,7 +56,6 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/certification', [CertificationController::class, 'submitDocument'])->name('certification.submit');
 });
 Route::middleware(['auth', 'verified', EnsureIsAdmin::class])
-use App\Http\Controllers\Admin\LoginController as AdminLoginController;
     ->prefix('admin')
     ->name('admin.')
     ->group(function () {


### PR DESCRIPTION
## Summary
- fix similar listings attribute accessor method
- remove stray `use` statement from web routes

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6866b17087488330819b0ef28f0f759b