### PR TITLE
Add blue-orange gradient theme

### DIFF
--- a/resources/js/Components/Layout/Footer.jsx
+++ b/resources/js/Components/Layout/Footer.jsx
@@ -2,7 +2,7 @@ import { Box, Text } from "@chakra-ui/react";
 
 export default function Footer() {
   return (
-    <Box bg="brand.600" color="white" py={4} textAlign="center">
+    <Box bgGradient="linear(to-r, brand.600, orange.500)" color="white" py={4} textAlign="center">
       <Text fontSize="sm">
         &copy; {new Date().getFullYear()} PRIMO. Tous droits réservés.
       </Text>

--- a/resources/js/theme.js
+++ b/resources/js/theme.js
@@ -34,10 +34,10 @@ const theme = extendTheme({
       },
       variants: {
         fancy: {
-          bgGradient: 'linear(to-r, brand.600, brand.400)',
+          bgGradient: 'linear(to-r, brand.600, orange.400)',
           color: 'white',
           _hover: {
-            bgGradient: 'linear(to-r, brand.700, brand.500)',
+            bgGradient: 'linear(to-r, brand.700, orange.500)',
           },
         },
       },

--- a/resources/scss/index.scss
+++ b/resources/scss/index.scss
@@ -33,7 +33,7 @@ body {
   left: 50%;
   bottom: 1rem;
   transform: translate(-50%, 100%);
-  background: #2a6ab2;
+  background: linear-gradient(to right, #2a6ab2, #ff8c00);
   color: #fff;
   padding: 0.75rem 1.25rem;
   border-radius: 0.375rem;


### PR DESCRIPTION
## Summary
- blend brand blue with orange on main button style
- update footer with matching gradient
- show toasts using blue-orange gradient background

## Testing
- `php artisan test` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b9b51a9c8330b2a876eb11dc9760