### PR TITLE
Remove message toasts and stop polling

### DIFF
--- a/resources/js/Components/UI/NotificationBell.jsx
+++ b/resources/js/Components/UI/NotificationBell.jsx
@@ -14,14 +14,12 @@ import {
 import { BellIcon } from '@chakra-ui/icons';
 import { Link, usePage } from '@inertiajs/react';
 import { useEffect, useState, useRef } from 'react';
-import { useToast } from '@chakra-ui/react';
 import axios from 'axios';
 
 export default function NotificationBell() {
   const { unreadNotifications = 0 } = usePage().props;
   const [notifications, setNotifications] = useState([]);
   const firstLoad = useRef(true);
-  const toast = useToast();
 
   const loadNotifications = async () => {
     try {
@@ -34,19 +32,6 @@ export default function NotificationBell() {
         return;
       }
 
-      const currentIds = notifications.map(n => n.id);
-      data.forEach(n => {
-        if (!currentIds.includes(n.id) && !toast.isActive(n.id)) {
-          toast({
-            id: n.id,
-            title: 'Nouveau message',
-            description: n.data.content,
-            status: 'info',
-            duration: 5000,
-            isClosable: true,
-          });
-        }
-      });
       setNotifications(data);
     } catch (e) {}
   };

--- a/resources/js/Pages/Messages/Index.jsx
+++ b/resources/js/Pages/Messages/Index.jsx
@@ -62,24 +62,6 @@ export default function Index({ conversations: initial = {}, current }) {
     }
   };
 
-  const refreshMessages = async () => {
-    if (!active) return;
-    try {
-      const res = await axios.get(`/conversations/${active.id}`);
-      setMessages(res.data.messages);
-      const other = res.data.seller_id === auth.user.id ? res.data.buyer : res.data.seller;
-      setPartner(other);
-      setTimeout(() => {
-        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-      }, 0);
-      errorShown.current = false;
-    } catch (e) {
-      if (!errorShown.current) {
-        sweetAlert('Erreur lors du rafraîchissement des messages');
-        errorShown.current = true;
-      }
-    }
-  };
 
   const send = async () => {
     if (!content) return;
@@ -107,11 +89,6 @@ export default function Index({ conversations: initial = {}, current }) {
     }
   }, [conversations, current]);
 
-  useEffect(() => {
-    if (!active) return;
-    const interval = setInterval(refreshMessages, 5000);
-    return () => clearInterval(interval);
-  }, [active]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });


### PR DESCRIPTION
## Summary
- remove toast notifications from `NotificationBell`
- stop polling conversations for new messages

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b9f919348330b1ade0c848f30836