### PR TITLE
Fix participant middleware for conversations

### DIFF
--- a/app/Http/Middleware/EnsureUserIsParticipant.php
+++ b/app/Http/Middleware/EnsureUserIsParticipant.php
@@ -4,12 +4,18 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
+use App\Models\Conversation;
 
 class EnsureUserIsParticipant
 {
     public function handle(Request $request, Closure $next)
     {
         $conversation = $request->route('conversation');
+
+        if (!$conversation instanceof Conversation) {
+            $conversation = Conversation::findOrFail($conversation);
+            $request->route()->setParameter('conversation', $conversation);
+        }
 
         if (!in_array(auth()->id(), [$conversation->buyer_id, $conversation->seller_id])) {
             abort(Response::HTTP_FORBIDDEN, 'Vous ne participez pas à cette conversation.');


### PR DESCRIPTION
## Summary
- ensure `EnsureUserIsParticipant` loads the Conversation model when passed an ID

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6866bb1873f083308d4b76c88d4a53af