### PR TITLE
Fix messages retrieval for conversations

### DIFF
--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -11,6 +11,14 @@ use Illuminate\Support\Facades\Storage;
 
 class MessageController extends Controller
 {
+    public function index(Conversation $conversation)
+    {
+        $this->authorize('view', $conversation);
+        $messages = $conversation->messages()->with('sender')->orderBy('created_at')->get();
+
+        return response()->json($messages);
+    }
+
     public function store(Request $request, Conversation $conversation)
     {
         if ($conversation->is_closed) {

--- a/resources/js/Pages/Messages/Index.jsx
+++ b/resources/js/Pages/Messages/Index.jsx
@@ -30,7 +30,8 @@ export default function Index({ conversations: initial = {}, current }) {
     try {
       setActive(conv);
       const res = await axios.get(`/conversations/${conv.id}`);
-      setMessages(res.data.messages);
+      const messagesRes = await axios.get(`/conversations/${conv.id}/messages`);
+      setMessages(messagesRes.data);
       const other = res.data.seller_id === auth.user.id ? res.data.buyer : res.data.seller;
       setPartner(other);
       setTimeout(() => {

--- a/routes/web.php
+++ b/routes/web.php
@@ -100,6 +100,7 @@ Route::middleware(['auth', 'verified', 'certified'])->group(function () {
     Route::post('/conversations/{conversation}/read', [ConversationController::class, 'markAsRead']);
     Route::post('/conversations/{conversation}/unread', [ConversationController::class, 'markAsUnread']);
 
+    Route::get('/conversations/{conversation}/messages', [MessageController::class, 'index'])->middleware('participant');
     Route::post('/conversations/{conversation}/messages', [MessageController::class, 'store'])->middleware('participant');
     Route::post('/conversations/{conversation}/meetings', [MeetingController::class, 'store'])->middleware('participant');
     Route::post('/meetings/{meeting}/status', [MeetingController::class, 'update'])->middleware('participant');


### PR DESCRIPTION
## Summary
- add endpoint to list messages of a conversation
- wire front-end to use new endpoint when opening a conversation

## Testing
- `npm test` *(fails: missing script)*
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866bc6623ec8330afad27716dd3e774