### PR TITLE
Add user listings management

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -119,6 +119,19 @@ class PageController extends Controller
         return Inertia::render('Account/Clockings');
     }
 
+    public function myListings()
+    {
+        $listings = Listing::where('user_id', auth()->id())
+            ->with('category')
+            ->withCount('conversations')
+            ->latest()
+            ->get();
+
+        return Inertia::render('Listing/MyListings', [
+            'listings' => $listings,
+        ]);
+    }
+
     public function messages(Request $request)
     {
         $conversations = Conversation::where('buyer_id', auth()->id())

--- a/resources/js/Components/Layout/Navbar.jsx
+++ b/resources/js/Components/Layout/Navbar.jsx
@@ -95,6 +95,7 @@ export default function Navbar() {
                         <MenuItem as={Link} href="/messages">Messages</MenuItem>
                         <MenuItem as={Link} href="/profile">Profil</MenuItem>
                         <MenuItem as={Link} href="/account/clockings">Pointage</MenuItem>
+                        <MenuItem as={Link} href="/account/listings">Mes annonces</MenuItem>
                         <MenuItem as={Link} href={route('account.settings')}>Paramètres du compte</MenuItem>
                         <MenuItem as={Link} href="/logout" method="post">Déconnexion</MenuItem>
                     </MenuList>

--- a/resources/js/Pages/Listing/MyListings.jsx
+++ b/resources/js/Pages/Listing/MyListings.jsx
@@ -1,0 +1,55 @@
+import { Box, Table, Thead, Tbody, Tr, Th, Td, Button, Heading, Text } from '@chakra-ui/react';
+import { Link } from '@inertiajs/react';
+import { useState } from 'react';
+import axios from 'axios';
+import sweetAlert from '@/libs/sweetalert';
+
+export default function MyListings({ listings: initial = [] }) {
+  const [listings, setListings] = useState(initial);
+
+  const remove = async (id) => {
+    if (!confirm('Supprimer cette annonce ?')) return;
+    try {
+      await axios.delete(`/listings/${id}`);
+      setListings(ls => ls.filter(l => l.id !== id));
+      sweetAlert('Annonce supprimée', 'success');
+    } catch (e) {
+      sweetAlert("Erreur lors de la suppression");
+    }
+  };
+
+  return (
+    <Box>
+      <Heading size="lg" mb={6}>Mes annonces</Heading>
+      {listings.length === 0 ? (
+        <Text>Aucune annonce pour le moment.</Text>
+      ) : (
+        <Table variant="simple">
+          <Thead>
+            <Tr>
+              <Th>Titre</Th>
+              <Th>Status</Th>
+              <Th>Demandes</Th>
+              <Th>Actions</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {listings.map(l => (
+              <Tr key={l.id}>
+                <Td>{l.title}</Td>
+                <Td>{l.status}</Td>
+                <Td>{l.conversations_count}</Td>
+                <Td>
+                  <Button as={Link} href={`/listings/${l.id}/edit`} size="xs" mr={2}>Modifier</Button>
+                  <Button size="xs" colorScheme="red" variant="outline" onClick={() => remove(l.id)}>
+                    Supprimer
+                  </Button>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      )}
+    </Box>
+  );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -143,6 +143,7 @@ Route::middleware(['auth'])->group(function () {
     Route::post('/listings/{listing}/favorite', [ListingController::class, 'toggle'])->name('favorites.toggle');
     Route::get('/account/settings', [PageController::class, 'accountSettings'])->name('account.settings');
     Route::get('/account/clockings', [PageController::class, 'clockings'])->name('account.clockings');
+    Route::get('/account/listings', [PageController::class, 'myListings'])->name('account.listings');
 
     Route::get('/saved-searches', [SavedSearchController::class, 'index'])->name('searches.index');
     Route::post('/saved-searches', [SavedSearchController::class, 'store'])->name('searches.store');


### PR DESCRIPTION
## Summary
- expose a new page to list user listings
- link page in navbar
- add route and controller method to retrieve listings

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686980ad3eac833087e759815daf092d