### PR TITLE
Clarify focus on property sales

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-APP_NAME=Laravel
+APP_NAME=ProprioPlus
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Ce projet utilise **Laravel 12** avec **React** et Inertia pour construire une plateforme de vente immobilière. Tout le contenu est prévu en français.
 
+> **Note :** L'application est uniquement orientée vers la **vente** de biens immobiliers. Aucune fonctionnalité de prêt ou de financement n'est prévue.
+
 Un système de recommandations propose désormais automatiquement des annonces en fonction des recherches sauvegardées et des favoris des utilisateurs.
 
 ## Installation

--- a/resources/js/Components/Home/CreateListingCTA.jsx
+++ b/resources/js/Components/Home/CreateListingCTA.jsx
@@ -15,7 +15,7 @@ export default function CreateListingCTA() {
           />
           <Box textAlign={{ base: "center", md: "left" }}>
             <Heading as="h2" size="xl" mb={4}>
-              Envie de vendre ou louer un bien ?
+              Envie de vendre votre bien ?
             </Heading>
             <Text fontSize="lg" mb={6}>
               Publiez votre annonce en quelques minutes et touchez des milliers

--- a/resources/js/Components/Listing/ListingCard.jsx
+++ b/resources/js/Components/Listing/ListingCard.jsx
@@ -90,7 +90,7 @@ export default function ListingCard({ listing, onToggle }) {
                 <Stack spacing={3} p={4} flex="1">
                     <Text fontSize="xl" fontWeight="bold">{listing.title}</Text>
                     <Text fontSize="md" color="gray.600">{listing.city}, {listing.postal_code}</Text>
-                    <Text fontSize="lg" fontWeight="bold">{listing.price} €<Text as="span" fontWeight="normal" color="gray.500"> / nuit</Text></Text>
+                    <Text fontSize="lg" fontWeight="bold">{listing.price} €</Text>
                     <Text fontSize="sm" color="gray.600">Surface : {listing.surface} m²</Text>
                     <Text fontSize="sm" color="gray.600">Pièces : {listing.rooms}, Chambres : {listing.bedrooms}, Sdb : {listing.bathrooms}</Text>
                     <HStack spacing={3} pt={2}>


### PR DESCRIPTION
## Summary
- rename example `APP_NAME` to `ProprioPlus`
- clarify in the README that the app only handles property sales and not loans
- remove nightly pricing and update CTA text

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686a8c0a780c833094b920e4b49ac66d