### PR TITLE
Improve admin UI styling

### DIFF
--- a/resources/js/Components/Admin/AdminLayout.jsx
+++ b/resources/js/Components/Admin/AdminLayout.jsx
@@ -1,4 +1,15 @@
-import { MantineProvider, AppShell, NavLink, Group, Menu, Button } from '@mantine/core';
+import {
+  Box,
+  Flex,
+  Link as ChakraLink,
+  Icon,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  Button,
+  Text,
+} from '@chakra-ui/react';
 import { Link, usePage } from '@inertiajs/react';
 import AdminNotificationBell from './AdminNotificationBell';
 import { FaUsers, FaFileAlt, FaHome, FaFlag, FaClock } from 'react-icons/fa';
@@ -7,38 +18,53 @@ export default function AdminLayout({ children }) {
   const { auth } = usePage().props;
 
   return (
-    <MantineProvider>
-      <AppShell padding="md" navbar={{ width: 200 }} header={{ height: 60 }}>
-      <AppShell.Navbar p="xs">
-        <NavLink component={Link} href="/admin/users" label="Utilisateurs" icon={<FaUsers size={14} />} />
-        <NavLink component={Link} href="/admin/listings" label="Annonces" icon={<FaHome size={14} />} />
-        <NavLink component={Link} href="/admin/pages" label="Pages" icon={<FaFileAlt size={14} />} />
-        <NavLink component={Link} href="/admin/reports" label="Signalements" icon={<FaFlag size={14} />} />
-        <NavLink component={Link} href="/admin/clockings" label="Pointages" icon={<FaClock size={14} />} />
-      </AppShell.Navbar>
-
-      <AppShell.Header p="xs">
-        <Group justify="space-between" h="100%">
-          <Group>
-            <Link href="/">Accueil</Link>
-          </Group>
-          <Group>
+    <Flex minH="100vh">
+      <Box w="200px" bg="brand.600" color="white" p={4}>
+        <Flex direction="column" as="nav" gap={2} fontSize="sm">
+          <ChakraLink as={Link} href="/admin/users" display="flex" alignItems="center" gap={2}>
+            <Icon as={FaUsers} />
+            <Text>Utilisateurs</Text>
+          </ChakraLink>
+          <ChakraLink as={Link} href="/admin/listings" display="flex" alignItems="center" gap={2}
+            >
+            <Icon as={FaHome} />
+            <Text>Annonces</Text>
+          </ChakraLink>
+          <ChakraLink as={Link} href="/admin/pages" display="flex" alignItems="center" gap={2}
+            >
+            <Icon as={FaFileAlt} />
+            <Text>Pages</Text>
+          </ChakraLink>
+          <ChakraLink as={Link} href="/admin/reports" display="flex" alignItems="center" gap={2}
+            >
+            <Icon as={FaFlag} />
+            <Text>Signalements</Text>
+          </ChakraLink>
+          <ChakraLink as={Link} href="/admin/clockings" display="flex" alignItems="center" gap={2}
+            >
+            <Icon as={FaClock} />
+            <Text>Pointages</Text>
+          </ChakraLink>
+        </Flex>
+      </Box>
+      <Box flex="1" bg="gray.50">
+        <Flex as="header" bg="white" px={4} py={2} justify="space-between" align="center" shadow="sm">
+          <ChakraLink as={Link} href="/">Accueil</ChakraLink>
+          <Flex align="center" gap={3}>
             <AdminNotificationBell />
             <Menu>
-              <Menu.Target>
-                <Button variant="subtle">{auth.user.first_name}</Button>
-              </Menu.Target>
-              <Menu.Dropdown>
-                <Menu.Item component={Link} href="/">Aller au site</Menu.Item>
-                <Menu.Item component={Link} href="/admin/logout" method="post">Déconnexion</Menu.Item>
-              </Menu.Dropdown>
+              <MenuButton as={Button} variant="ghost">
+                {auth.user.first_name}
+              </MenuButton>
+              <MenuList>
+                <MenuItem as={Link} href="/">Aller au site</MenuItem>
+                <MenuItem as={Link} href="/admin/logout" method="post">Déconnexion</MenuItem>
+              </MenuList>
             </Menu>
-          </Group>
-        </Group>
-      </AppShell.Header>
-
-      <AppShell.Main>{children}</AppShell.Main>
-      </AppShell>
-    </MantineProvider>
+          </Flex>
+        </Flex>
+        <Box p={4}>{children}</Box>
+      </Box>
+    </Flex>
   );
 }

--- a/resources/js/Components/Admin/AdminNotificationBell.jsx
+++ b/resources/js/Components/Admin/AdminNotificationBell.jsx
@@ -1,4 +1,12 @@
-import { ActionIcon, Indicator, Menu, Text } from '@mantine/core';
+import {
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  Badge,
+  Text,
+} from '@chakra-ui/react';
 import { FaBell } from 'react-icons/fa';
 import { useEffect, useState } from 'react';
 import axios from 'axios';
@@ -29,29 +37,43 @@ export default function AdminNotificationBell() {
   };
 
   return (
-    <Menu shadow="md" width={250}>
-      <Menu.Target>
-        <Indicator color="red" disabled={unreadCount === 0} label={unreadCount} size={16}>
-          <ActionIcon variant="subtle" size="lg">
-            <FaBell />
-          </ActionIcon>
-        </Indicator>
-      </Menu.Target>
-      <Menu.Dropdown>
+    <Menu>
+      <MenuButton
+        as={IconButton}
+        icon={<FaBell />}
+        variant="ghost"
+        position="relative"
+      >
+        {unreadCount > 0 && (
+          <Badge
+            colorScheme="red"
+            borderRadius="full"
+            position="absolute"
+            top="0"
+            right="0"
+            fontSize="0.6em"
+          >
+            {unreadCount}
+          </Badge>
+        )}
+      </MenuButton>
+      <MenuList>
         {notifications.length === 0 ? (
-          <Menu.Item>Aucune notification</Menu.Item>
+          <MenuItem>Aucune notification</MenuItem>
         ) : (
           notifications.map((n) => (
-            <Menu.Item
+            <MenuItem
               key={n.id}
               onClick={() => markAsRead(n.id)}
-              color={n.read_at ? undefined : 'blue'}
+              color={n.read_at ? undefined : 'blue.600'}
             >
-              <Text size="sm">Nouvelle demande de certification de {n.data.name}</Text>
-            </Menu.Item>
+              <Text fontSize="sm">
+                Nouvelle demande de certification de {n.data.name}
+              </Text>
+            </MenuItem>
           ))
         )}
-      </Menu.Dropdown>
+      </MenuList>
     </Menu>
   );
 }

--- a/resources/js/Pages/Admin/Auth/Login.jsx
+++ b/resources/js/Pages/Admin/Auth/Login.jsx
@@ -1,15 +1,16 @@
 import { useForm } from '@inertiajs/react';
 import useErrorAlert from '@/hooks/useErrorAlert';
 import {
-  TextInput,
-  PasswordInput,
-  Checkbox,
-  Paper,
-  Title,
-  Container,
+  Box,
   Button,
-} from '@mantine/core';
-import { MantineProvider } from '@mantine/core';
+  Checkbox,
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  Heading,
+  Input,
+  VStack,
+} from '@chakra-ui/react';
 
 export default function AdminLogin() {
   const { data, setData, post, processing, errors } = useForm({
@@ -26,42 +27,44 @@ export default function AdminLogin() {
   };
 
   return (
-    <Container size={420} my={40}>
-      <Title align="center" mb="md">
-        Connexion administrateur
-      </Title>
-      <Paper withBorder shadow="md" p="md">
+    <Flex minH="100vh" align="center" justify="center" bg="gray.50">
+      <Box bg="white" p={8} rounded="md" shadow="md" w="full" maxW="md">
+        <Heading size="lg" textAlign="center" mb={6}>
+          Connexion administrateur
+        </Heading>
         <form onSubmit={submit}>
-          <TextInput
-            label="Email"
-            placeholder="Votre email"
-            value={data.email}
-            onChange={(e) => setData('email', e.target.value)}
-            error={errors.email}
-            required
-          />
-          <PasswordInput
-            label="Mot de passe"
-            placeholder="Votre mot de passe"
-            value={data.password}
-            onChange={(e) => setData('password', e.target.value)}
-            error={errors.password}
-            mt="md"
-            required
-          />
-          <Checkbox
-            label="Se souvenir de moi"
-            checked={data.remember}
-            onChange={(e) => setData('remember', e.currentTarget.checked)}
-            mt="md"
-          />
-          <Button fullWidth mt="xl" type="submit" loading={processing}>
-            Se connecter
-          </Button>
+          <VStack spacing={4} align="stretch">
+            <FormControl isInvalid={errors.email}>
+              <Input
+                placeholder="Votre email"
+                value={data.email}
+                onChange={(e) => setData('email', e.target.value)}
+              />
+              <FormErrorMessage>{errors.email}</FormErrorMessage>
+            </FormControl>
+            <FormControl isInvalid={errors.password}>
+              <Input
+                type="password"
+                placeholder="Votre mot de passe"
+                value={data.password}
+                onChange={(e) => setData('password', e.target.value)}
+              />
+              <FormErrorMessage>{errors.password}</FormErrorMessage>
+            </FormControl>
+            <Checkbox
+              isChecked={data.remember}
+              onChange={(e) => setData('remember', e.target.checked)}
+            >
+              Se souvenir de moi
+            </Checkbox>
+            <Button colorScheme="brand" type="submit" w="full" isLoading={processing}>
+              Se connecter
+            </Button>
+          </VStack>
         </form>
-      </Paper>
-    </Container>
+      </Box>
+    </Flex>
   );
 }
 
-AdminLogin.layout = page => <MantineProvider>{page}</MantineProvider>;
+AdminLogin.layout = (page) => page;

--- a/resources/js/Pages/Admin/Clockings/Index.jsx
+++ b/resources/js/Pages/Admin/Clockings/Index.jsx
@@ -1,4 +1,15 @@
-import { Box, Table, Flex, Button, Text } from '@mantine/core';
+import {
+  Box,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Flex,
+  Button,
+  Text,
+} from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import { route } from 'ziggy-js';
@@ -19,30 +30,30 @@ export default function Index() {
 
   return (
     <Box>
-      <Table striped withTableBorder>
-        <thead>
-          <tr>
-            <th>Utilisateur</th>
-            <th>Entrée</th>
-            <th>Sortie</th>
-            <th>Note</th>
-          </tr>
-        </thead>
-        <tbody>
+      <Table variant="striped" colorScheme="gray" size="sm">
+        <Thead>
+          <Tr>
+            <Th>Utilisateur</Th>
+            <Th>Entrée</Th>
+            <Th>Sortie</Th>
+            <Th>Note</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
           {clockings.map(c => (
-            <tr key={c.id}>
-              <td>{c.user.first_name} {c.user.last_name}</td>
-              <td>{new Date(c.clock_in_at).toLocaleString()}</td>
-              <td>{c.clock_out_at ? new Date(c.clock_out_at).toLocaleString() : '—'}</td>
-              <td>{c.note || '—'}</td>
-            </tr>
+            <Tr key={c.id}>
+              <Td>{c.user.first_name} {c.user.last_name}</Td>
+              <Td>{new Date(c.clock_in_at).toLocaleString()}</Td>
+              <Td>{c.clock_out_at ? new Date(c.clock_out_at).toLocaleString() : '—'}</Td>
+              <Td>{c.note || '—'}</Td>
+            </Tr>
           ))}
-        </tbody>
+        </Tbody>
       </Table>
-      <Flex mt="md" justify="space-between" align="center">
-        <Button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>Précédent</Button>
+      <Flex mt={4} justify="space-between" align="center">
+        <Button onClick={() => setPage(p => Math.max(1, p - 1))} isDisabled={page === 1}>Précédent</Button>
         <Text>{page} / {lastPage}</Text>
-        <Button onClick={() => setPage(p => Math.min(lastPage, p + 1))} disabled={page === lastPage}>Suivant</Button>
+        <Button onClick={() => setPage(p => Math.min(lastPage, p + 1))} isDisabled={page === lastPage}>Suivant</Button>
       </Flex>
     </Box>
   );

--- a/resources/js/Pages/Admin/Reports/Index.jsx
+++ b/resources/js/Pages/Admin/Reports/Index.jsx
@@ -1,4 +1,16 @@
-import { Box, Table, Flex, Button, Select, Text } from '@mantine/core';
+import {
+  Box,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Button,
+  Flex,
+  Select,
+  Text,
+} from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import { route } from 'ziggy-js';
@@ -24,38 +36,38 @@ export default function Index() {
 
   return (
     <Box>
-      <Table striped withTableBorder>
-        <thead>
-          <tr>
-            <th>Reporter</th>
-            <th>Signalé</th>
-            <th>Annonce</th>
-            <th>Raison</th>
-            <th>Status</th>
-          </tr>
-        </thead>
-        <tbody>
+      <Table variant="striped" colorScheme="gray" size="sm">
+        <Thead>
+          <Tr>
+            <Th>Reporter</Th>
+            <Th>Signalé</Th>
+            <Th>Annonce</Th>
+            <Th>Raison</Th>
+            <Th>Status</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
           {reports.map(r => (
-            <tr key={r.id}>
-              <td>{r.reporter.first_name} {r.reporter.last_name}</td>
-              <td>{r.reported ? r.reported.first_name + ' ' + r.reported.last_name : '—'}</td>
-              <td>{r.conversation ? r.conversation.listing.title : '—'}</td>
-              <td>{r.reason}</td>
-              <td>
-                <Select size="xs" value={r.status} onChange={val => updateStatus(r.id, val)} data={[
-                  { value: 'pending', label: 'pending' },
-                  { value: 'reviewed', label: 'reviewed' },
-                  { value: 'blocked', label: 'blocked' },
-                ]} />
-              </td>
-            </tr>
+            <Tr key={r.id}>
+              <Td>{r.reporter.first_name} {r.reporter.last_name}</Td>
+              <Td>{r.reported ? r.reported.first_name + ' ' + r.reported.last_name : '—'}</Td>
+              <Td>{r.conversation ? r.conversation.listing.title : '—'}</Td>
+              <Td>{r.reason}</Td>
+              <Td>
+                <Select size="xs" value={r.status} onChange={(e) => updateStatus(r.id, e.target.value)}>
+                  <option value="pending">pending</option>
+                  <option value="reviewed">reviewed</option>
+                  <option value="blocked">blocked</option>
+                </Select>
+              </Td>
+            </Tr>
           ))}
-        </tbody>
+        </Tbody>
       </Table>
-      <Flex mt="md" justify="space-between" align="center">
-        <Button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>Précédent</Button>
+      <Flex mt={4} justify="space-between" align="center">
+        <Button onClick={() => setPage(p => Math.max(1, p - 1))} isDisabled={page === 1}>Précédent</Button>
         <Text>{page} / {lastPage}</Text>
-        <Button onClick={() => setPage(p => Math.min(lastPage, p + 1))} disabled={page === lastPage}>Suivant</Button>
+        <Button onClick={() => setPage(p => Math.min(lastPage, p + 1))} isDisabled={page === lastPage}>Suivant</Button>
       </Flex>
     </Box>
   );

--- a/resources/js/Pages/Admin/Users/Index.jsx
+++ b/resources/js/Pages/Admin/Users/Index.jsx
@@ -1,4 +1,17 @@
-import { Box, Table, TextInput, Button, Flex, Text, Anchor } from '@mantine/core';
+import {
+  Box,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Input,
+  Button,
+  Flex,
+  Text,
+  Link,
+} from '@chakra-ui/react';
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 import { router } from '@inertiajs/react';
@@ -52,49 +65,49 @@ export default function Index() {
 
   return (
     <Box>
-      <TextInput
+      <Input
         placeholder="Rechercher..."
-        mb="sm"
+        mb={2}
         value={query}
         onChange={(e) => {
           setQuery(e.target.value);
           setPage(1);
         }}
       />
-      <Table striped withTableBorder>
-        <thead>
-          <tr>
-            <th style={{ cursor: 'pointer' }} onClick={() => handleSort('last_name')}>Nom {sort === 'last_name' && (dir === 'asc' ? '▲' : '▼')}</th>
-            <th style={{ cursor: 'pointer' }} onClick={() => handleSort('email')}>Email {sort === 'email' && (dir === 'asc' ? '▲' : '▼')}</th>
-            <th style={{ cursor: 'pointer' }} onClick={() => handleSort('certification_status')}>Status {sort === 'certification_status' && (dir === 'asc' ? '▲' : '▼')}</th>
-            <th>Document</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
+      <Table variant="striped" colorScheme="gray" size="sm">
+        <Thead>
+          <Tr>
+            <Th cursor="pointer" onClick={() => handleSort('last_name')}>Nom {sort === 'last_name' && (dir === 'asc' ? '▲' : '▼')}</Th>
+            <Th cursor="pointer" onClick={() => handleSort('email')}>Email {sort === 'email' && (dir === 'asc' ? '▲' : '▼')}</Th>
+            <Th cursor="pointer" onClick={() => handleSort('certification_status')}>Status {sort === 'certification_status' && (dir === 'asc' ? '▲' : '▼')}</Th>
+            <Th>Document</Th>
+            <Th>Actions</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
           {users.map(u => (
-            <tr key={u.id}>
-              <td>{u.first_name} {u.last_name}</td>
-              <td>{u.email}</td>
-              <td>{u.certification_status || '—'}</td>
-              <td>
+            <Tr key={u.id}>
+              <Td>{u.first_name} {u.last_name}</Td>
+              <Td>{u.email}</Td>
+              <Td>{u.certification_status || '—'}</Td>
+              <Td>
                 {u.identity_document && (
-                  <Anchor onClick={() => viewDocument(u.id)}>Voir</Anchor>
+                  <Link onClick={() => viewDocument(u.id)}>Voir</Link>
                 )}
-              </td>
-              <td>
-                <Button size="xs" mr={4} onClick={() => certify(u.id)}>Certifier</Button>
-                <Button size="xs" mr={4} variant="outline" onClick={() => refuse(u.id)}>Refuser</Button>
-                <Button size="xs" variant="default" onClick={() => reupload(u.id)}>Demander nouveau doc</Button>
-              </td>
-            </tr>
+              </Td>
+              <Td>
+                <Button size="xs" mr={2} onClick={() => certify(u.id)}>Certifier</Button>
+                <Button size="xs" mr={2} variant="outline" onClick={() => refuse(u.id)}>Refuser</Button>
+                <Button size="xs" variant="ghost" onClick={() => reupload(u.id)}>Demander nouveau doc</Button>
+              </Td>
+            </Tr>
           ))}
-        </tbody>
+        </Tbody>
       </Table>
-      <Flex mt="md" justify="space-between" align="center">
-        <Button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>Précédent</Button>
+      <Flex mt={4} justify="space-between" align="center">
+        <Button onClick={() => setPage(p => Math.max(1, p - 1))} isDisabled={page === 1}>Précédent</Button>
         <Text>{page} / {lastPage}</Text>
-        <Button onClick={() => setPage(p => Math.min(lastPage, p + 1))} disabled={page === lastPage}>Suivant</Button>
+        <Button onClick={() => setPage(p => Math.min(lastPage, p + 1))} isDisabled={page === lastPage}>Suivant</Button>
       </Flex>
     </Box>
   );


### PR DESCRIPTION
## Summary
- restyle admin login using Chakra UI components
- convert admin layout to Chakra UI
- switch admin notification bell to Chakra UI
- update admin pages for users, reports, and clockings to use Chakra UI

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac42022e883308dd05046c3521039