### PR TITLE
Display existing listing media during edit

### DIFF
--- a/app/Http/Controllers/FileController.php
+++ b/app/Http/Controllers/FileController.php
@@ -1,0 +1,20 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\File;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+
+class FileController extends Controller
+{
+    public function destroy(File $file)
+    {
+        $ownerId = $file->fileable?->user_id;
+        if ($ownerId && $ownerId !== Auth::id()) {
+            abort(403);
+        }
+        Storage::disk('public')->delete($file->path);
+        $file->delete();
+        return response()->json(['message' => 'Fichier supprimé']);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\Admin\ListingController as AdminListingController;
 use App\Http\Controllers\Admin\PageController as AdminPageController;
 use App\Http\Controllers\Admin\ReportController as AdminReportController;
 use App\Http\Controllers\Admin\ClockingController as AdminClockingController;
+use App\Http\Controllers\FileController;
 use App\Http\Middleware\EnsureIsAdmin;
 use App\Http\Controllers\Admin\LoginController as AdminLoginController;
 use Illuminate\Http\Request;
@@ -92,6 +93,7 @@ Route::middleware(['auth', 'verified', 'terms', 'certified'])->group(function ()
     Route::post('listings/{listing}/exclusive-mandate', [ListingController::class, 'signMandate'])->name('listings.mandate.sign');
     Route::post('listings/{listing}/mark-as-sold', [ListingController::class, 'markAsSold'])->name('listings.sold');
     Route::post('listings/{listing}/archive', [ListingController::class, 'archive'])->name('listings.archive');
+    Route::delete('/files/{file}', [FileController::class, 'destroy'])->name('files.destroy');
 });
 Route::middleware(['auth', 'verified', 'terms', 'certified'])->group(function () {
     Route::get('/conversations', [ConversationController::class, 'index']);


### PR DESCRIPTION
## Summary
- show gallery images and documents on the listing edit page
- allow deletion of existing media
- add missing React import on Edit page
- introduce `FileController` with destroy action
- expose DELETE `/files/{file}` route

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686acd47fac88330b193bd2f7f195f99