### PR TITLE
Fix edit page validation and gallery preview

### DIFF
--- a/app/Http/Requests/StoreListingRequest.php
+++ b/app/Http/Requests/StoreListingRequest.php
@@ -12,7 +12,7 @@ class StoreListingRequest extends FormRequest
 
     public function rules(): array
     {
-        return [
+        $rules = [
             'title' => 'required|string|max:255',
             'description' => 'required|string',
             'price' => 'required|numeric|min:0',
@@ -36,5 +36,13 @@ class StoreListingRequest extends FormRequest
             'documents.*' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:4096',
             'gallery.*' => 'nullable|image|max:4096',
         ];
+
+        if ($this->isMethod('put') || $this->isMethod('patch')) {
+            foreach ($rules as $field => $rule) {
+                $rules[$field] = 'sometimes|' . $rule;
+            }
+        }
+
+        return $rules;
     }
 }


### PR DESCRIPTION
## Summary
- allow partial validation when updating listings
- improve Edit listing gallery with dropzone preview and file limit

## Testing
- `composer test` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad2575e888330bbe52249ad155a18