### PR TITLE
Fix gallery update form

### DIFF
--- a/resources/js/Pages/Listing/Edit.jsx
+++ b/resources/js/Pages/Listing/Edit.jsx
@@ -66,7 +66,7 @@ export default function Edit({ listing, categories: initialCategories = [] }) {
     address: listing.address || '',
     latitude: listing.latitude || '',
     longitude: listing.longitude || '',
-    gallery: null,
+    gallery: [],
     documents: null,
   });
 


### PR DESCRIPTION
## Summary
- avoid sending `null` for the gallery field when editing listings

## Testing
- `composer test` *(fails: command not found)*
- `npm test` *(fails: no test script and npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686ae31f5df4833083f514236a02aea1