### PR TITLE
Enhance home page with guidance sections

### DIFF
--- a/resources/js/Components/Home/ClientAdviceSection.jsx
+++ b/resources/js/Components/Home/ClientAdviceSection.jsx
@@ -1,0 +1,27 @@
+import { Box, Heading, SimpleGrid, Text, Icon } from "@chakra-ui/react";
+import { FaSearch, FaHandshake, FaBell } from "react-icons/fa";
+import FadeInSection from "../UI/FadeInSection";
+
+const advices = [
+  { icon: FaSearch, text: "Affinez vos recherches avec nos filtres avancés." },
+  { icon: FaHandshake, text: "Contactez rapidement les vendeurs pour organiser une visite." },
+  { icon: FaBell, text: "Activez les alertes pour ne rater aucune nouvelle annonce." },
+];
+
+export default function ClientAdviceSection() {
+  return (
+    <FadeInSection>
+      <Box py={10} textAlign="center">
+        <Heading size="lg" mb={6}>Nos conseils pour réussir</Heading>
+        <SimpleGrid columns={{ base: 1, md: 3 }} spacing={6}>
+          {advices.map((a, i) => (
+            <Box key={i} p={5} borderRadius="lg" bg="white" boxShadow="sm">
+              <Icon as={a.icon} boxSize={8} color="brand.500" mb={3} />
+              <Text>{a.text}</Text>
+            </Box>
+          ))}
+        </SimpleGrid>
+      </Box>
+    </FadeInSection>
+  );
+}

--- a/resources/js/Components/Home/PriceEstimationSection.jsx
+++ b/resources/js/Components/Home/PriceEstimationSection.jsx
@@ -1,0 +1,33 @@
+import { Box, Heading, SimpleGrid, VStack, Text } from "@chakra-ui/react";
+import FadeInSection from "../UI/FadeInSection";
+
+const data = [
+  { label: "Appartement", value: 3000 },
+  { label: "Maison", value: 2500 },
+  { label: "Terrain", value: 1500 },
+];
+
+export default function PriceEstimationSection() {
+  const max = Math.max(...data.map((d) => d.value));
+  return (
+    <FadeInSection>
+      <Box py={10} textAlign="center">
+        <Heading size="lg" mb={6}>Estimation des prix au m²</Heading>
+        <SimpleGrid columns={{ base: 1, md: 3 }} spacing={6}>
+          {data.map((d) => (
+            <VStack key={d.label} spacing={3}>
+              <Box
+                h={`${(d.value / max) * 150}px`}
+                w="40px"
+                bg="brand.500"
+                borderRadius="md"
+              />
+              <Text fontWeight="bold">{d.value} €/m²</Text>
+              <Text>{d.label}</Text>
+            </VStack>
+          ))}
+        </SimpleGrid>
+      </Box>
+    </FadeInSection>
+  );
+}

--- a/resources/js/Components/Home/UsageInstructionsSection.jsx
+++ b/resources/js/Components/Home/UsageInstructionsSection.jsx
@@ -1,0 +1,30 @@
+import { Box, Heading, VStack, HStack, Icon, Text } from "@chakra-ui/react";
+import { FaSearch, FaRegStar, FaEnvelope } from "react-icons/fa";
+import FadeInSection from "../UI/FadeInSection";
+
+const steps = [
+  { icon: FaSearch, title: "Recherchez", text: "Utilisez la barre de recherche pour trouver des biens." },
+  { icon: FaRegStar, title: "Sauvegardez", text: "Ajoutez vos annonces favorites pour recevoir des recommandations." },
+  { icon: FaEnvelope, title: "Contactez", text: "Échangez avec le vendeur directement via notre messagerie." },
+];
+
+export default function UsageInstructionsSection() {
+  return (
+    <FadeInSection>
+      <Box py={10}>
+        <Heading size="lg" mb={6} textAlign="center">Comment utiliser ProprioPlus ?</Heading>
+        <VStack spacing={6} align="stretch" maxW="3xl" mx="auto">
+          {steps.map((s, i) => (
+            <HStack key={i} spacing={4} align="flex-start">
+              <Icon as={s.icon} boxSize={8} color="brand.500" />
+              <Box>
+                <Text fontWeight="bold">{s.title}</Text>
+                <Text>{s.text}</Text>
+              </Box>
+            </HStack>
+          ))}
+        </VStack>
+      </Box>
+    </FadeInSection>
+  );
+}

--- a/resources/js/Pages/Home/Index.jsx
+++ b/resources/js/Pages/Home/Index.jsx
@@ -1,9 +1,6 @@
 import {
   Box,
   Heading,
-  VStack,
-  Text,
-  Button,
   Image,
   SimpleGrid,
   useBreakpointValue
@@ -11,6 +8,9 @@ import {
 import SearchBar from "@/Components/Listing/SearchBar.jsx";
 import FeatureSection from "@/Components/Listing/FeatureSection";
 import CreateListingCTA from "@/Components/Home/CreateListingCTA";
+import PriceEstimationSection from "@/Components/Home/PriceEstimationSection";
+import ClientAdviceSection from "@/Components/Home/ClientAdviceSection";
+import UsageInstructionsSection from "@/Components/Home/UsageInstructionsSection";
 import FadeInSection from "@/Components/UI/FadeInSection";
 import ListingCard from "@/Components/Listing/ListingCard";
 
@@ -43,6 +43,9 @@ export default function Home({ bestMatches = [] }) {
 
         <FeatureSection />
         <CreateListingCTA />
+        <UsageInstructionsSection />
+        <PriceEstimationSection />
+        <ClientAdviceSection />
 
         {bestMatches.length > 0 && (
             <Box mt={10} pb={10}>


### PR DESCRIPTION
## Summary
- add price estimation chart section
- show advice for new clients
- display instructions on how to use the platform
- load new sections in home page

## Testing
- `php artisan test` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bedec4ec883309a712579bf5dced4