### PR TITLE
Improve messaging endpoints and media support

### DIFF
--- a/app/Http/Controllers/ConversationController.php
+++ b/app/Http/Controllers/ConversationController.php
@@ -109,7 +109,15 @@ class ConversationController extends Controller
             ->where('is_read', false)
             ->update(['is_read' => true]);
 
-        $conversation = $conversation->fresh()->load(['messages.sender', 'seller', 'buyer', 'listing', 'meetings']);
+        $conversation = $conversation->fresh()->load([
+            'seller',
+            'buyer',
+            'listing',
+            'meetings',
+            'messages' => function ($q) {
+                $q->orderBy('created_at')->with('sender');
+            },
+        ]);
 
         return response()->json($conversation);
     }

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -5,7 +5,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Message extends Model
 {
-    protected $fillable = ['conversation_id', 'sender_id', 'content', 'is_read'];
+    protected $fillable = [
+        'conversation_id',
+        'sender_id',
+        'content',
+        'file',
+        'is_read'
+    ];
+
+    protected $appends = ['file_url'];
 
     public function conversation() {
         return $this->belongsTo(Conversation::class);
@@ -13,5 +21,10 @@ class Message extends Model
 
     public function sender() {
         return $this->belongsTo(User::class, 'sender_id');
+    }
+
+    public function getFileUrlAttribute()
+    {
+        return $this->file ? '/storage/' . ltrim($this->file, '/') : null;
     }
 }

--- a/database/migrations/2025_07_04_000001_add_file_to_messages_table.php
+++ b/database/migrations/2025_07_04_000001_add_file_to_messages_table.php
@@ -1,0 +1,20 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->string('file')->nullable()->after('content');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->dropColumn('file');
+        });
+    }
+};

--- a/resources/js/Pages/Messages/Index.jsx
+++ b/resources/js/Pages/Messages/Index.jsx
@@ -1,4 +1,4 @@
-import { Box, Heading, HStack, VStack, Text, Input, Button, Avatar, IconButton } from '@chakra-ui/react';
+import { Box, Heading, HStack, VStack, Text, Input, Button, Avatar, IconButton, Link } from '@chakra-ui/react';
 import { FaCheckDouble, FaEnvelope, FaEnvelopeOpen, FaReply } from 'react-icons/fa';
 import ListingCard from '@/Components/Listing/ListingCard';
 import { usePage } from '@inertiajs/react';
@@ -29,9 +29,8 @@ export default function Index({ conversations: initial = {}, current }) {
   const loadConversation = async (conv) => {
     try {
       setActive(conv);
-      const res = await axios.get(`/conversations/${conv.id}`);
-      const messagesRes = await axios.get(`/conversations/${conv.id}/messages`);
-      setMessages(messagesRes.data);
+      const res = await axios.get(`/api/conversations/${conv.id}`);
+      setMessages(res.data.messages || []);
       const other = res.data.seller_id === auth.user.id ? res.data.buyer : res.data.seller;
       setPartner(other);
       setTimeout(() => {
@@ -48,17 +47,18 @@ export default function Index({ conversations: initial = {}, current }) {
 
   const loadMore = async () => {
     if (!nextPage) return;
-    const res = await axios.get(nextPage);
+    const apiUrl = nextPage.replace('/conversations', '/api/conversations');
+    const res = await axios.get(apiUrl);
     setConversations(cs => [...cs, ...res.data.data]);
     setNextPage(res.data.next_page_url);
   };
 
   const toggleRead = async (conv) => {
     if (conv.unread_count > 0) {
-      await axios.post(`/conversations/${conv.id}/read`);
+      await axios.post(`/api/conversations/${conv.id}/read`);
       setConversations(cs => cs.map(c => c.id === conv.id ? { ...c, unread_count: 0 } : c));
     } else {
-      await axios.post(`/conversations/${conv.id}/unread`);
+      await axios.post(`/api/conversations/${conv.id}/unread`);
       setConversations(cs => cs.map(c => c.id === conv.id ? { ...c, unread_count: 1 } : c));
     }
   };
@@ -67,7 +67,7 @@ export default function Index({ conversations: initial = {}, current }) {
   const send = async () => {
     if (!content) return;
     try {
-      const res = await axios.post(`/conversations/${active.id}/messages`, { content });
+      const res = await axios.post(`/api/conversations/${active.id}/messages`, { content });
       setContent('');
       setMessages((ms) => [...ms, res.data]);
       setTimeout(() => {
@@ -165,6 +165,9 @@ export default function Index({ conversations: initial = {}, current }) {
                         </HStack>
                         <HStack>
                           <Text>{m.content}</Text>
+                          {m.file_url && (
+                            <Link href={m.file_url} isExternal ml={2}>Fichier</Link>
+                          )}
                           {isMe && <FaCheckDouble color={m.is_read ? 'blue' : 'gray'} />}
                         </HStack>
                       </VStack>
@@ -176,6 +179,9 @@ export default function Index({ conversations: initial = {}, current }) {
                   <Box key={m.id} alignSelf={isMe ? 'flex-end' : 'flex-start'} bg={isMe ? 'brand.200' : 'gray.100'} borderRadius="md" p={2}>
                     <HStack>
                       <Text>{m.content}</Text>
+                      {m.file_url && (
+                        <Link href={m.file_url} isExternal ml={2}>Fichier</Link>
+                      )}
                       {isMe && (
                         <FaCheckDouble color={m.is_read ? 'blue' : 'gray'} />
                       )}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,8 @@
 
 use App\Http\Controllers\ListingController;
 use App\Http\Controllers\CategoryController;
+use App\Http\Controllers\ConversationController;
+use App\Http\Controllers\MessageController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -10,3 +12,11 @@ Route::get('/user', function (Request $request) {
 })->middleware('auth:sanctum');
 Route::get('/listings/map', [ListingController::class, 'all']);
 Route::get('/categories', [CategoryController::class, 'index']);
+
+Route::middleware(['auth:sanctum', 'verified', 'terms', 'certified'])->group(function () {
+    Route::get('/conversations', [ConversationController::class, 'index']);
+    Route::post('/conversations', [ConversationController::class, 'store']);
+    Route::get('/conversations/{conversation}', [ConversationController::class, 'show'])->middleware('participant');
+    Route::post('/conversations/{conversation}/messages', [MessageController::class, 'store'])->middleware('participant');
+    Route::get('/conversations/{conversation}/messages', [MessageController::class, 'index'])->middleware('participant');
+});


### PR DESCRIPTION
## Summary
- allow messages to store attached files
- load conversation messages via ordered eager loading
- expose messaging endpoints through the API
- show download links for message files on the frontend
- adjust frontend to use new API endpoints

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bed8501848330a783ca802f689ae1