### PR TITLE
Add interactive visit scheduling

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-leaflet": "^4.2.1",
     "react-slick": "^0.30.3",
     "recoil": "^0.7.7",
+    "react-datepicker": "^4.24.0",
     "ziggy-js": "^2.5.3",
     "react-signature-canvas": "^1.0.6"
   }

--- a/resources/js/Components/Meeting/VisitScheduler.jsx
+++ b/resources/js/Components/Meeting/VisitScheduler.jsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import {
+  Button,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Textarea,
+  useDisclosure,
+} from '@chakra-ui/react';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+import axios from 'axios';
+
+export default function VisitScheduler({ conversationId, onScheduled }) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [date, setDate] = useState(new Date());
+  const [agenda, setAgenda] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const submit = async () => {
+    setLoading(true);
+    try {
+      await axios.post(`/conversations/${conversationId}/meetings`, {
+        scheduled_at: date.toISOString(),
+        type: 'visit',
+        agenda,
+      });
+      onClose();
+      setAgenda('');
+      if (onScheduled) onScheduled();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Button size="sm" onClick={onOpen} colorScheme="brand">
+        Proposer une visite
+      </Button>
+      <Modal isOpen={isOpen} onClose={onClose} isCentered>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Proposer une visite</ModalHeader>
+          <ModalBody>
+            <DatePicker
+              selected={date}
+              onChange={setDate}
+              showTimeSelect
+              dateFormat="Pp"
+              className="chakra-input"
+            />
+            <Textarea
+              mt={4}
+              placeholder="Détails ou agenda"
+              value={agenda}
+              onChange={(e) => setAgenda(e.target.value)}
+            />
+          </ModalBody>
+          <ModalFooter>
+            <Button mr={3} onClick={onClose} variant="ghost">
+              Annuler
+            </Button>
+            <Button colorScheme="brand" onClick={submit} isLoading={loading}>
+              Envoyer
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add `react-datepicker` for calendar widget support
- create `VisitScheduler` component with calendar-based modal
- integrate visit scheduling and meeting management in messaging

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bee5060088330b23a055749c3ccfb