### PR TITLE
Add conversation status middleware

### DIFF
--- a/app/Http/Middleware/EnsureConversationIsOpen.php
+++ b/app/Http/Middleware/EnsureConversationIsOpen.php
@@ -1,0 +1,36 @@
+<?php
+namespace App\Http\Middleware;
+
+use App\Models\Conversation;
+use App\Models\Meeting;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureConversationIsOpen
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $conversation = $request->route('conversation');
+
+        if (!$conversation && $request->route('meeting')) {
+            $meeting = $request->route('meeting');
+            if (!$meeting instanceof Meeting) {
+                $meeting = Meeting::findOrFail($meeting);
+                $request->route()->setParameter('meeting', $meeting);
+            }
+            $conversation = $meeting->conversation;
+        }
+
+        if (!$conversation instanceof Conversation) {
+            $conversation = Conversation::findOrFail($conversation);
+            $request->route()->setParameter('conversation', $conversation);
+        }
+
+        if ($conversation->is_blocked || $conversation->is_closed) {
+            abort(Response::HTTP_FORBIDDEN, 'Cette conversation est bloquée.');
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -21,6 +21,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'admin' => \App\Http\Middleware\EnsureIsAdmin::class,
             'participant' => \App\Http\Middleware\EnsureUserIsParticipant::class,
             'terms' => \App\Http\Middleware\EnsureTermsAccepted::class,
+            'conversation.open' => \App\Http\Middleware\EnsureConversationIsOpen::class,
         ]);
 
         $middleware->web(append: [

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,18 @@
+<?php
+namespace Database\Factories;
+
+use App\Models\Category;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word(),
+            'description' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/factories/ConversationFactory.php
+++ b/database/factories/ConversationFactory.php
@@ -1,0 +1,24 @@
+<?php
+namespace Database\Factories;
+
+use App\Models\Conversation;
+use App\Models\Listing;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ConversationFactory extends Factory
+{
+    protected $model = Conversation::class;
+
+    public function definition(): array
+    {
+        return [
+            'listing_id' => Listing::factory(),
+            'seller_id' => User::factory(),
+            'buyer_id' => User::factory(),
+            'is_blocked' => false,
+            'is_closed' => false,
+            'subject' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/factories/ListingFactory.php
+++ b/database/factories/ListingFactory.php
@@ -1,0 +1,32 @@
+<?php
+namespace Database\Factories;
+
+use App\Enums\ListingStatus;
+use App\Models\Category;
+use App\Models\Listing;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ListingFactory extends Factory
+{
+    protected $model = Listing::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->sentence(4),
+            'description' => $this->faker->paragraph(),
+            'price' => $this->faker->numberBetween(50000, 300000),
+            'surface' => $this->faker->numberBetween(20, 200),
+            'rooms' => $this->faker->numberBetween(1, 5),
+            'bedrooms' => $this->faker->numberBetween(1, 5),
+            'bathrooms' => $this->faker->numberBetween(1, 2),
+            'city' => $this->faker->city(),
+            'postal_code' => $this->faker->postcode(),
+            'address' => $this->faker->address(),
+            'status' => ListingStatus::Active,
+            'user_id' => User::factory(),
+            'category_id' => Category::factory(),
+        ];
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -106,9 +106,9 @@ Route::middleware(['auth', 'verified', 'terms', 'certified'])->group(function ()
     Route::post('/conversations/{conversation}/unread', [ConversationController::class, 'markAsUnread']);
 
     Route::get('/conversations/{conversation}/messages', [MessageController::class, 'index'])->middleware('participant');
-    Route::post('/conversations/{conversation}/messages', [MessageController::class, 'store'])->middleware('participant');
-    Route::post('/conversations/{conversation}/meetings', [MeetingController::class, 'store'])->middleware('participant');
-    Route::post('/meetings/{meeting}/status', [MeetingController::class, 'update'])->middleware('participant');
+    Route::post('/conversations/{conversation}/messages', [MessageController::class, 'store'])->middleware(['participant', 'conversation.open']);
+    Route::post('/conversations/{conversation}/meetings', [MeetingController::class, 'store'])->middleware(['participant', 'conversation.open']);
+    Route::post('/meetings/{meeting}/status', [MeetingController::class, 'update'])->middleware(['participant', 'conversation.open']);
     Route::post('/messages/{message}/read', [MessageController::class, 'markAsRead']);
 
     Route::get('/notifications', [NotificationController::class, 'index']);

--- a/tests/Feature/ConversationStatusMiddlewareTest.php
+++ b/tests/Feature/ConversationStatusMiddlewareTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace Tests\Feature;
+
+use App\Models\Conversation;
+use App\Models\Listing;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConversationStatusMiddlewareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeConversation(array $attributes = []): Conversation
+    {
+        $seller = User::factory()->create([
+            'certification_status' => 'certifié',
+            'terms_accepted_at' => now(),
+        ]);
+        $buyer = User::factory()->create([
+            'certification_status' => 'certifié',
+            'terms_accepted_at' => now(),
+        ]);
+        $listing = Listing::factory()->create(['user_id' => $seller->id]);
+
+        return Conversation::factory()->create(array_merge([
+            'listing_id' => $listing->id,
+            'seller_id' => $seller->id,
+            'buyer_id' => $buyer->id,
+        ], $attributes));
+    }
+
+    public function test_blocked_conversation_rejects_new_messages(): void
+    {
+        $conversation = $this->makeConversation(['is_blocked' => true]);
+        $buyer = User::find($conversation->buyer_id);
+
+        $response = $this->actingAs($buyer)->post("/conversations/{$conversation->id}/messages", [
+            'content' => 'Bonjour',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_closed_conversation_rejects_meeting_creation(): void
+    {
+        $conversation = $this->makeConversation(['is_closed' => true]);
+        $seller = User::find($conversation->seller_id);
+
+        $response = $this->actingAs($seller)->post("/conversations/{$conversation->id}/meetings", [
+            'scheduled_at' => now()->addDay(),
+            'type' => 'meeting',
+        ]);
+
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary
- add `EnsureConversationIsOpen` middleware
- register new middleware alias
- apply middleware to conversation message and meeting routes
- add factories for Category, Listing and Conversation
- test middleware blocks messages or meetings on closed conversations

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bee7c03c083308a60135e1bb24a0a