### PR TITLE
Fix conversation middleware on API

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,6 @@ Route::middleware(['auth:sanctum', 'verified', 'terms', 'certified'])->group(fun
     Route::get('/conversations', [ConversationController::class, 'index']);
     Route::post('/conversations', [ConversationController::class, 'store']);
     Route::get('/conversations/{conversation}', [ConversationController::class, 'show'])->middleware('participant');
-    Route::post('/conversations/{conversation}/messages', [MessageController::class, 'store'])->middleware('participant');
+    Route::post('/conversations/{conversation}/messages', [MessageController::class, 'store'])->middleware(['participant', 'conversation.open']);
     Route::get('/conversations/{conversation}/messages', [MessageController::class, 'index'])->middleware('participant');
 });


### PR DESCRIPTION
## Summary
- ensure conversation open status is enforced for API messages

## Testing
- `composer test` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2d9cb6548330a4f61efb4b576a23