### PR TITLE
Add PDF attestation generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,34 @@ Exécuter les tests avec :
 php artisan test
 ```
 
+## Signature électronique et génération de PDF
+
+Le projet s'appuie sur le composant React **react-signature-canvas** pour
+capturer les signatures. Pour générer des PDF, installez l'extension gratuite
+`barryvdh/laravel-dompdf` :
+
+```bash
+composer require barryvdh/laravel-dompdf
+```
+
+Une fois la dépendance ajoutée, un nouveau point d'entrée permet de télécharger
+une **attestation de loyer** signée :
+
+```text
+GET /pdf/attestation/{listing}
+```
+
+Cette route génère un PDF au format proche des attestations de loyer françaises
+en incluant la signature enregistrée.
+
+### Étapes de signature
+
+Le processus de vente est sécurisé par plusieurs documents électroniques :
+
+1. **Mandat de vente** : le propriétaire signe le mandat directement depuis l'application.
+2. **Bon de visite** : chaque visiteur peut signer numériquement son passage.
+3. **Offre d'achat** : l'acheteur propose son prix via un formulaire signé.
+4. **Compromis de vente** puis **acte définitif** : les deux parties finalisent la vente.
+
+Les signatures sont stockées en base et peuvent être intégrées dans les PDF générés via l'API ci-dessus.
+

--- a/app/Http/Controllers/PdfController.php
+++ b/app/Http/Controllers/PdfController.php
@@ -1,0 +1,26 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Listing;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Support\Facades\Storage;
+
+class PdfController extends Controller
+{
+    public function attestation(Listing $listing)
+    {
+        $signature = $listing->documentsToSign()
+            ->where('type', 'mandat_exclusif')
+            ->first()?->signatures()
+            ->where('user_id', auth()->id())
+            ->first();
+
+        $pdf = Pdf::loadView('pdf.attestation', [
+            'listing' => $listing,
+            'user' => auth()->user(),
+            'signaturePath' => $signature ? Storage::disk('public')->path($signature->file_path) : null,
+        ]);
+
+        return $pdf->download('attestation-'.$listing->id.'.pdf');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "laravel/jetstream": "^5.3",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.10.1",
-        "tightenco/ziggy": "^2.5"
+        "tightenco/ziggy": "^2.5",
+        "barryvdh/laravel-dompdf": "^2.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/resources/views/pdf/attestation.blade.php
+++ b/resources/views/pdf/attestation.blade.php
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: sans-serif; font-size: 14px; }
+        h1 { text-align: center; font-size: 20px; margin-bottom: 20px; }
+        .section { margin-bottom: 10px; }
+        .signature { margin-top: 40px; text-align: right; }
+        .signature img { height: 80px; }
+    </style>
+</head>
+<body>
+    <h1>Attestation de loyer</h1>
+    <div class="section">
+        <strong>Propriétaire :</strong> {{ \$user->name }}
+    </div>
+    <div class="section">
+        <strong>Bien :</strong> {{ \$listing->title }}
+    </div>
+    <div class="section">
+        <strong>Adresse :</strong> {{ \$listing->address }}
+    </div>
+    <div class="signature">
+        @if(\$signaturePath)
+            <img src="{{ \$signaturePath }}" alt="Signature">
+        @else
+            <em>Signature non disponible</em>
+        @endif
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -160,6 +160,9 @@ Route::middleware(['auth'])->group(function () {
     Route::delete('/saved-searches/{search}', [SavedSearchController::class, 'destroy'])->name('searches.destroy');
 
     Route::get('/recommendations', [ListingController::class, 'recommendations'])->name('listings.recommendations');
+
+    // Génération d'une attestation de loyer au format PDF
+    Route::get('/pdf/attestation/{listing}', [\App\Http\Controllers\PdfController::class, 'attestation'])->name('pdf.attestation');
 });
 
 Route::middleware(['auth', 'verified', 'terms', 'certified'])->group(function () {


### PR DESCRIPTION
## Summary
- install barryvdh/laravel-dompdf
- create PdfController and a Blade view for the attestation
- expose new `/pdf/attestation/{listing}` route
- document how to sign and get a PDF

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2de8d8008330bf47afaa3faf8258