### PR TITLE
Fix axios config for auth

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -2,3 +2,4 @@ import axios from 'axios';
 window.axios = axios;
 
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+window.axios.defaults.withCredentials = true;


### PR DESCRIPTION
## Summary
- set `axios.defaults.withCredentials` so cookies are sent with API requests

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c340aa9688330a7c2cb7d3385eb4b