### PR TITLE
Improve admin dashboard and user management

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -1,0 +1,33 @@
+<?php
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Models\Listing;
+use App\Models\Report;
+use App\Models\Page;
+use Inertia\Inertia;
+
+class DashboardController extends Controller
+{
+    public function index()
+    {
+        $stats = [
+            'users' => User::count(),
+            'listings' => Listing::count(),
+            'active_listings' => Listing::active()->count(),
+            'reports' => Report::count(),
+            'pending_reports' => Report::where('status', 'pending')->count(),
+            'pages' => Page::count(),
+        ];
+
+        $listingStatus = Listing::selectRaw('status, count(*) as count')
+            ->groupBy('status')
+            ->pluck('count', 'status');
+
+        return Inertia::render('Admin/Home/Index', [
+            'stats' => $stats,
+            'listingStatus' => $listingStatus,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Admin/LoginController.php
+++ b/app/Http/Controllers/Admin/LoginController.php
@@ -39,7 +39,7 @@ class LoginController extends Controller
             ]);
         }
 
-        return redirect()->intended('/admin/users');
+        return redirect()->intended('/admin');
     }
 
     public function logout(Request $request)

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -20,7 +20,7 @@ class UserController extends Controller
 
     public function data(Request $request)
     {
-        $query = User::withBasicInfo()->select('certification_status', 'identity_document');
+        $query = User::withBasicInfo()->addSelect('certification_status', 'identity_document');
 
         if ($search = $request->input('search')) {
             $query->where(function ($q) use ($search) {

--- a/database/seeders/PageSeeder.php
+++ b/database/seeders/PageSeeder.php
@@ -47,6 +47,17 @@ class PageSeeder extends Seeder
                     ],
                 ],
             ],
+            [
+                'slug' => 'faq',
+                'title' => 'FAQ',
+                'sections' => [
+                    [
+                        'id' => 'intro',
+                        'text' => 'Questions fréquemment posées à propos du service.',
+                        'image' => '/images/auth-back.png',
+                    ],
+                ],
+            ],
         ];
 
         foreach ($pages as $data) {

--- a/resources/js/Components/Admin/AdminLayout.jsx
+++ b/resources/js/Components/Admin/AdminLayout.jsx
@@ -12,7 +12,7 @@ import {
 } from '@chakra-ui/react';
 import { Link, usePage } from '@inertiajs/react';
 import AdminNotificationBell from './AdminNotificationBell';
-import { FaUsers, FaFileAlt, FaHome, FaFlag, FaClock } from 'react-icons/fa';
+import { FaUsers, FaFileAlt, FaHome, FaFlag, FaClock, FaChartPie } from 'react-icons/fa';
 
 export default function AdminLayout({ children }) {
   const { auth } = usePage().props;
@@ -21,6 +21,10 @@ export default function AdminLayout({ children }) {
     <Flex minH="100vh">
       <Box w="200px" bg="brand.600" color="white" p={4}>
         <Flex direction="column" as="nav" gap={2} fontSize="sm">
+          <ChakraLink as={Link} href="/admin" display="flex" alignItems="center" gap={2}>
+            <Icon as={FaChartPie} />
+            <Text>Dashboard</Text>
+          </ChakraLink>
           <ChakraLink as={Link} href="/admin/users" display="flex" alignItems="center" gap={2}>
             <Icon as={FaUsers} />
             <Text>Utilisateurs</Text>

--- a/resources/js/Pages/Admin/Home/Index.jsx
+++ b/resources/js/Pages/Admin/Home/Index.jsx
@@ -1,0 +1,60 @@
+import {
+  Box,
+  SimpleGrid,
+  Stat,
+  StatLabel,
+  StatNumber,
+  Heading,
+  Flex,
+  Text,
+} from '@chakra-ui/react';
+import AdminLayout from '@/Components/Admin/AdminLayout';
+
+export default function Index({ stats = {}, listingStatus = {} }) {
+  const max = Math.max(...Object.values(listingStatus), 0);
+  return (
+    <Box>
+      <Heading size="lg" mb={6}>Tableau de bord</Heading>
+      <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4} mb={8}>
+        <Stat>
+          <StatLabel>Utilisateurs</StatLabel>
+          <StatNumber>{stats.users}</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Annonces</StatLabel>
+          <StatNumber>{stats.listings}</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Annonces actives</StatLabel>
+          <StatNumber>{stats.active_listings}</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Signalements</StatLabel>
+          <StatNumber>{stats.reports}</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Signalements en attente</StatLabel>
+          <StatNumber>{stats.pending_reports}</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Pages</StatLabel>
+          <StatNumber>{stats.pages}</StatNumber>
+        </Stat>
+      </SimpleGrid>
+      <Box>
+        <Heading size="md" mb={4}>Annonces par statut</Heading>
+        <Flex align="flex-end" gap={4} h="200px">
+          {Object.entries(listingStatus).map(([status, count]) => (
+            <Box key={status} textAlign="center" flex="1">
+              <Box bg="brand.600" h={`${max ? (count / max) * 100 : 0}%`} minH="4" />
+              <Text fontSize="sm" mt={1}>{status}</Text>
+              <Text fontSize="sm">{count}</Text>
+            </Box>
+          ))}
+        </Flex>
+      </Box>
+    </Box>
+  );
+}
+
+Index.layout = (page) => <AdminLayout>{page}</AdminLayout>;

--- a/resources/js/Pages/Admin/Users/Index.jsx
+++ b/resources/js/Pages/Admin/Users/Index.jsx
@@ -79,7 +79,9 @@ export default function Index() {
           <Tr>
             <Th cursor="pointer" onClick={() => handleSort('last_name')}>Nom {sort === 'last_name' && (dir === 'asc' ? '▲' : '▼')}</Th>
             <Th cursor="pointer" onClick={() => handleSort('email')}>Email {sort === 'email' && (dir === 'asc' ? '▲' : '▼')}</Th>
+            <Th cursor="pointer" onClick={() => handleSort('phone')}>Téléphone {sort === 'phone' && (dir === 'asc' ? '▲' : '▼')}</Th>
             <Th cursor="pointer" onClick={() => handleSort('certification_status')}>Status {sort === 'certification_status' && (dir === 'asc' ? '▲' : '▼')}</Th>
+            <Th>Dernière activité</Th>
             <Th>Document</Th>
             <Th>Actions</Th>
           </Tr>
@@ -89,7 +91,9 @@ export default function Index() {
             <Tr key={u.id}>
               <Td>{u.first_name} {u.last_name}</Td>
               <Td>{u.email}</Td>
+              <Td>{u.phone}</Td>
               <Td>{u.certification_status || '—'}</Td>
+              <Td>{u.last_active_at ? new Date(u.last_active_at).toLocaleString() : '—'}</Td>
               <Td>
                 {u.identity_document && (
                   <Link onClick={() => viewDocument(u.id)}>Voir</Link>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\Admin\ListingController as AdminListingController;
 use App\Http\Controllers\Admin\PageController as AdminPageController;
 use App\Http\Controllers\Admin\ReportController as AdminReportController;
 use App\Http\Controllers\Admin\ClockingController as AdminClockingController;
+use App\Http\Controllers\Admin\DashboardController as AdminDashboardController;
 use App\Http\Controllers\FileController;
 use App\Http\Middleware\EnsureIsAdmin;
 use App\Http\Controllers\Admin\LoginController as AdminLoginController;
@@ -61,6 +62,7 @@ Route::middleware(['auth', 'verified', 'terms', EnsureIsAdmin::class])
     ->prefix('admin')
     ->name('admin.')
     ->group(function () {
+        Route::get('/', [AdminDashboardController::class, 'index'])->name('dashboard');
         Route::get('/users', [AdminUserController::class, 'index'])->name('users.index');
         Route::get('/users/data', [AdminUserController::class, 'data'])->name('users.data');
         Route::get('/users/{user}/document', [AdminUserController::class, 'document'])->name('users.document');


### PR DESCRIPTION
## Summary
- fix admin login redirect to new dashboard
- add admin dashboard controller and route
- show dashboard link in admin layout and create dashboard page
- fix user query in admin controller
- expand user table with phone and activity columns
- seed an extra FAQ page for demo content

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c3d4c0fe48330887221cf65c18ae3