### PR TITLE
Fix query error and add success toast on user certification

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -21,7 +21,8 @@ class DashboardController extends Controller
             'pages' => Page::count(),
         ];
 
-        $listingStatus = Listing::selectRaw('status, count(*) as count')
+        $listingStatus = Listing::withoutEagerLoads()
+            ->selectRaw('status, count(*) as count')
             ->groupBy('status')
             ->pluck('count', 'status');
 

--- a/resources/js/Pages/Admin/Users/Index.jsx
+++ b/resources/js/Pages/Admin/Users/Index.jsx
@@ -16,6 +16,7 @@ import { useState, useEffect } from 'react';
 import axios from 'axios';
 import { router } from '@inertiajs/react';
 import { route } from 'ziggy-js';
+import sweetAlert from '@/libs/sweetalert';
 import AdminLayout from '@/Components/Admin/AdminLayout';
 
 export default function Index() {
@@ -47,8 +48,14 @@ export default function Index() {
     }
   };
 
-  const certify = (id) => {
-    router.post(route('admin.users.certify', id), {}, { onSuccess: fetchUsers });
+  const certify = async (id) => {
+    try {
+      const { data } = await axios.post(route('admin.users.certify', id));
+      sweetAlert(data.message, 'success');
+      fetchUsers();
+    } catch (e) {
+      sweetAlert('Erreur lors de la certification');
+    }
   };
 
   const refuse = (id) => {


### PR DESCRIPTION
## Summary
- fix admin dashboard listing status query by disabling eager loads
- show a success toast when certifying a user and refresh their status

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c3fd30490833082ef8ee0ca23f729