### PR TITLE
Fix Admin dashboard listing status count

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Models\Listing;
+use Illuminate\Support\Facades\DB;
 use App\Models\Report;
 use App\Models\Page;
 use Inertia\Inertia;
@@ -21,8 +22,11 @@ class DashboardController extends Controller
             'pages' => Page::count(),
         ];
 
-        $listingStatus = Listing::withoutEagerLoads()
-            ->selectRaw('status, count(*) as count')
+        // Use the query builder directly to avoid the default withCount
+        // defined on the Listing model which would otherwise add extra
+        // columns and break the GROUP BY query.
+        $listingStatus = DB::table('listings')
+            ->select('status', DB::raw('count(*) as count'))
             ->groupBy('status')
             ->pluck('count', 'status');
 


### PR DESCRIPTION
## Summary
- fix group-by query on admin dashboard when listing counts are retrieved

## Testing
- `composer install` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c424a8b988330b87ebfdd7293692f