### PR TITLE
Enhance admin dashboard analytics

### DIFF
--- a/resources/js/Pages/Admin/Home/Index.jsx
+++ b/resources/js/Pages/Admin/Home/Index.jsx
@@ -5,16 +5,79 @@ import {
   StatLabel,
   StatNumber,
   Heading,
-  Flex,
-  Text,
+  Select,
+  Button,
 } from '@chakra-ui/react';
+import { useEffect, useRef, useState } from 'react';
+import axios from 'axios';
 import AdminLayout from '@/Components/Admin/AdminLayout';
 
-export default function Index({ stats = {}, listingStatus = {} }) {
-  const max = Math.max(...Object.values(listingStatus), 0);
+export default function Index({ stats: initialStats = {}, listingStatus = {}, categories = {} }) {
+  const [stats, setStats] = useState(initialStats);
+  const [statusData, setStatusData] = useState(listingStatus);
+  const [categoryData, setCategoryData] = useState({});
+  const [filters, setFilters] = useState({ status: '', category_id: '' });
+  const statusChart = useRef(null);
+  const categoryChart = useRef(null);
+
+  const fetchData = async () => {
+    const { data } = await axios.get(route('admin.dashboard.data'), { params: filters });
+    setStats(data.stats);
+    setStatusData(data.listingStatus);
+    setCategoryData(data.listingCategories);
+  };
+
+  useEffect(() => { fetchData(); }, []);
+
+  useEffect(() => {
+    if (!window.Chart) return;
+    const statusCtx = document.getElementById('statusChart').getContext('2d');
+    if (statusChart.current) statusChart.current.destroy();
+    statusChart.current = new window.Chart(statusCtx, {
+      type: 'bar',
+      data: {
+        labels: Object.keys(statusData),
+        datasets: [{ data: Object.values(statusData), backgroundColor: '#3182ce' }]
+      },
+      options: { plugins: { legend: { display: false } } }
+    });
+
+    const catCtx = document.getElementById('categoryChart').getContext('2d');
+    if (categoryChart.current) categoryChart.current.destroy();
+    categoryChart.current = new window.Chart(catCtx, {
+      type: 'pie',
+      data: {
+        labels: Object.entries(categories).map(([_, name]) => name),
+        datasets: [{ data: Object.values(categoryData) }]
+      }
+    });
+  }, [statusData, categoryData]);
+
+  const handleChange = (e) => setFilters({ ...filters, [e.target.name]: e.target.value });
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    fetchData();
+  };
+
   return (
     <Box>
       <Heading size="lg" mb={6}>Tableau de bord</Heading>
+      <Box as="form" onSubmit={handleSubmit} mb={4} display="flex" gap={2} flexWrap="wrap">
+        <Select name="status" placeholder="Statut" value={filters.status} onChange={handleChange} w="200px">
+          <option value="">Tous</option>
+          {Object.keys(listingStatus).map((s) => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </Select>
+        <Select name="category_id" placeholder="Catégorie" value={filters.category_id} onChange={handleChange} w="200px">
+          <option value="">Toutes</option>
+          {Object.entries(categories).map(([id, name]) => (
+            <option key={id} value={id}>{name}</option>
+          ))}
+        </Select>
+        <Button type="submit">Filtrer</Button>
+      </Box>
       <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4} mb={8}>
         <Stat>
           <StatLabel>Utilisateurs</StatLabel>
@@ -41,17 +104,13 @@ export default function Index({ stats = {}, listingStatus = {} }) {
           <StatNumber>{stats.pages}</StatNumber>
         </Stat>
       </SimpleGrid>
-      <Box>
+      <Box mb={8}>
         <Heading size="md" mb={4}>Annonces par statut</Heading>
-        <Flex align="flex-end" gap={4} h="200px">
-          {Object.entries(listingStatus).map(([status, count]) => (
-            <Box key={status} textAlign="center" flex="1">
-              <Box bg="brand.600" h={`${max ? (count / max) * 100 : 0}%`} minH="4" />
-              <Text fontSize="sm" mt={1}>{status}</Text>
-              <Text fontSize="sm">{count}</Text>
-            </Box>
-          ))}
-        </Flex>
+        <canvas id="statusChart" height="200" />
+      </Box>
+      <Box>
+        <Heading size="md" mb={4}>Annonces par catégorie</Heading>
+        <canvas id="categoryChart" height="200" />
       </Box>
     </Box>
   );

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -16,6 +16,7 @@
         @viteReactRefresh
         @vite(['resources/js/app.jsx', "resources/js/Pages/{$page['component']}.jsx"])
         @inertiaHead
+        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     </head>
     <body class="font-sans antialiased">
         @inertia

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,6 +63,7 @@ Route::middleware(['auth', 'verified', 'terms', EnsureIsAdmin::class])
     ->name('admin.')
     ->group(function () {
         Route::get('/', [AdminDashboardController::class, 'index'])->name('dashboard');
+        Route::get('/dashboard/data', [AdminDashboardController::class, 'data'])->name('dashboard.data');
         Route::get('/users', [AdminUserController::class, 'index'])->name('users.index');
         Route::get('/users/data', [AdminUserController::class, 'data'])->name('users.data');
         Route::get('/users/{user}/document', [AdminUserController::class, 'document'])->name('users.document');


### PR DESCRIPTION
## Summary
- include Chart.js via CDN
- add stats filtering in `DashboardController`
- expose dashboard data route
- render charts with filters in Admin dashboard

## Testing
- `npm test` *(fails: missing script)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4405d4e483308513f59b9baf3c4b