### PR TITLE
Fix Chakra Stat usage

### DIFF
--- a/resources/js/Pages/Admin/Home/Index.jsx
+++ b/resources/js/Pages/Admin/Home/Index.jsx
@@ -96,10 +96,10 @@ export default function Index({ stats: initialStats = {}, listingStatus = {}, ca
   const StatCard = ({ icon, label, value }) => (
     <Box bg={cardBg} p={4} rounded="md" shadow="md" display="flex" alignItems="center" gap={3}>
       <Icon as={icon} boxSize={5} color="brand.600" />
-      <Box>
+      <Stat>
         <StatLabel>{label}</StatLabel>
         <StatNumber>{value}</StatNumber>
-      </Box>
+      </Stat>
     </Box>
   );
 


### PR DESCRIPTION
## Summary
- wrap `StatLabel` and `StatNumber` with `Stat` in admin dashboard

## Testing
- `npm run build` *(fails: vite not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4bd0a73c8330aa7b047cb06342da