### PR TITLE
Improve admin dashboard UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Exécuter les tests avec :
 php artisan test
 ```
 
+### Admin Permissions
+
+Toutes les routes sous le préfixe `/admin` sont protégées par le middleware `EnsureIsAdmin` qui vérifie que l'utilisateur possède le rôle `admin`.
+Assignez ce rôle à un utilisateur via la relation `roles` pour lui donner accès au panneau d'administration.
+
 ## Signature électronique et génération de PDF
 
 Le projet s'appuie sur le composant React **react-signature-canvas** pour

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -17,7 +17,14 @@ class DashboardController extends Controller
     {
         $stats = [
             'users' => User::count(),
+            'pending_users' => User::where('certification_status', 'en_attente')->count(),
+            'verified_users' => User::where('certification_status', 'certifié')->count(),
+            'online_users' => DB::table('sessions')
+                ->where('last_activity', '>=', now()->subMinutes(5)->timestamp)
+                ->distinct('user_id')->count('user_id'),
             'listings' => Listing::count(),
+            'pending_listings' => Listing::where('status', 'pending')->count(),
+            'sold_listings' => Listing::sold()->count(),
             'active_listings' => Listing::active()->count(),
             'reports' => Report::count(),
             'pending_reports' => Report::where('status', 'pending')->count(),
@@ -67,7 +74,14 @@ class DashboardController extends Controller
 
         $stats = [
             'users' => User::count(),
+            'pending_users' => User::where('certification_status', 'en_attente')->count(),
+            'verified_users' => User::where('certification_status', 'certifié')->count(),
+            'online_users' => DB::table('sessions')
+                ->where('last_activity', '>=', now()->subMinutes(5)->timestamp)
+                ->distinct('user_id')->count('user_id'),
             'listings' => $query->count(),
+            'pending_listings' => (clone $query)->where('status', 'pending')->count(),
+            'sold_listings' => (clone $query)->sold()->count(),
             'active_listings' => (clone $query)->where('status', 'active')->count(),
             'reports' => Report::count(),
             'pending_reports' => Report::where('status', 'pending')->count(),

--- a/app/Http/Controllers/Admin/ListingController.php
+++ b/app/Http/Controllers/Admin/ListingController.php
@@ -9,9 +9,11 @@ use Inertia\Inertia;
 
 class ListingController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
-        return Inertia::render('Admin/Listings/Index');
+        return Inertia::render('Admin/Listings/Index', [
+            'filters' => $request->only('status'),
+        ]);
     }
 
     public function data(Request $request)
@@ -20,6 +22,10 @@ class ListingController extends Controller
 
         if ($search = $request->input('search')) {
             $query->where('title', 'like', "%{$search}%");
+        }
+
+        if ($status = $request->input('status')) {
+            $query->where('status', $status);
         }
 
         $sort = $request->input('sort', 'created_at');

--- a/app/Http/Controllers/Admin/ReportController.php
+++ b/app/Http/Controllers/Admin/ReportController.php
@@ -8,16 +8,23 @@ use Inertia\Inertia;
 
 class ReportController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
-        return Inertia::render('Admin/Reports/Index');
+        return Inertia::render('Admin/Reports/Index', [
+            'filters' => $request->only('status'),
+        ]);
     }
 
     public function data(Request $request)
     {
-        $reports = Report::with(['reporter', 'reported', 'conversation.listing'])
-            ->orderByDesc('created_at')
-            ->paginate(20);
+        $query = Report::with(['reporter', 'reported', 'conversation.listing'])
+            ->orderByDesc('created_at');
+
+        if ($status = $request->input('status')) {
+            $query->where('status', $status);
+        }
+
+        $reports = $query->paginate(20);
         return $reports;
     }
 

--- a/resources/js/Components/Admin/AdminLayout.jsx
+++ b/resources/js/Components/Admin/AdminLayout.jsx
@@ -9,22 +9,27 @@ import {
   MenuItem,
   Button,
   Text,
+  IconButton,
+  Slide,
+  useDisclosure,
 } from '@chakra-ui/react';
 import { Link, usePage } from '@inertiajs/react';
 import AdminNotificationBell from './AdminNotificationBell';
-import { FaUsers, FaFileAlt, FaHome, FaFlag, FaClock, FaChartPie } from 'react-icons/fa';
+import { FaUsers, FaFileAlt, FaHome, FaFlag, FaClock, FaChartPie, FaBars } from 'react-icons/fa';
 
 export default function AdminLayout({ children }) {
   const { auth } = usePage().props;
+  const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: true });
 
   return (
-    <Flex minH="100vh">
-      <Box w="200px" bg="brand.600" color="white" p={4}>
-        <Flex direction="column" as="nav" gap={2} fontSize="sm">
-          <ChakraLink as={Link} href="/admin" display="flex" alignItems="center" gap={2}>
-            <Icon as={FaChartPie} />
-            <Text>Dashboard</Text>
-          </ChakraLink>
+    <Flex minH="100vh" bg="gray.100">
+      <Slide direction="left" in={isOpen} style={{ width: '200px' }}>
+        <Box w="200px" bg="brand.600" color="white" p={4} h="100vh" position="fixed">
+          <Flex direction="column" as="nav" gap={2} fontSize="sm">
+            <ChakraLink as={Link} href="/admin" display="flex" alignItems="center" gap={2}>
+              <Icon as={FaChartPie} />
+              <Text>Dashboard</Text>
+            </ChakraLink>
           <ChakraLink as={Link} href="/admin/users" display="flex" alignItems="center" gap={2}>
             <Icon as={FaUsers} />
             <Text>Utilisateurs</Text>
@@ -51,8 +56,10 @@ export default function AdminLayout({ children }) {
           </ChakraLink>
         </Flex>
       </Box>
-      <Box flex="1" bg="gray.50">
-        <Flex as="header" bg="white" px={4} py={2} justify="space-between" align="center" shadow="sm">
+      </Slide>
+      <Box flex="1" ml={isOpen ? '200px' : 0} transition="margin 0.2s" bg="gray.50">
+        <Flex as="header" bg="white" px={4} py={2} justify="space-between" align="center" shadow="sm" position="sticky" top={0} zIndex={1}>
+          <IconButton icon={<FaBars />} variant="ghost" onClick={onToggle} aria-label="Toggle menu" />
           <ChakraLink as={Link} href="/">Accueil</ChakraLink>
           <Flex align="center" gap={3}>
             <AdminNotificationBell />

--- a/resources/js/Pages/Admin/Home/Index.jsx
+++ b/resources/js/Pages/Admin/Home/Index.jsx
@@ -9,6 +9,7 @@ import {
   Button,
   Icon,
   useColorModeValue,
+  Link as ChakraLink,
 } from '@chakra-ui/react';
 import {
   FaUsers,
@@ -16,7 +17,11 @@ import {
   FaCheckCircle,
   FaFlag,
   FaFileAlt,
+  FaListUl,
 } from 'react-icons/fa';
+import { motion } from 'framer-motion';
+import { Link } from '@inertiajs/react';
+import { route } from 'ziggy-js';
 import { useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import AdminLayout from '@/Components/Admin/AdminLayout';
@@ -93,14 +98,26 @@ export default function Index({ stats: initialStats = {}, listingStatus = {}, ca
     fetchData();
   };
 
-  const StatCard = ({ icon, label, value }) => (
-    <Box bg={cardBg} p={4} rounded="md" shadow="md" display="flex" alignItems="center" gap={3}>
-      <Icon as={icon} boxSize={5} color="brand.600" />
-      <Stat>
-        <StatLabel>{label}</StatLabel>
-        <StatNumber>{value}</StatNumber>
-      </Stat>
-    </Box>
+  const MotionBox = motion(Box);
+  const StatLinkCard = ({ icon, label, value, href }) => (
+    <ChakraLink as={Link} href={href} _hover={{ textDecoration: 'none' }}>
+      <MotionBox
+        bg={cardBg}
+        p={4}
+        rounded="md"
+        shadow="md"
+        display="flex"
+        alignItems="center"
+        gap={3}
+        whileHover={{ scale: 1.05 }}
+      >
+        <Icon as={icon} boxSize={5} color="brand.600" />
+        <Stat>
+          <StatLabel>{label}</StatLabel>
+          <StatNumber>{value}</StatNumber>
+        </Stat>
+      </MotionBox>
+    </ChakraLink>
   );
 
   return (
@@ -122,12 +139,17 @@ export default function Index({ stats: initialStats = {}, listingStatus = {}, ca
         <Button type="submit">Filtrer</Button>
       </Box>
       <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} spacing={4} mb={8}>
-        <StatCard icon={FaUsers} label="Utilisateurs" value={stats.users} />
-        <StatCard icon={FaHome} label="Annonces" value={stats.listings} />
-        <StatCard icon={FaCheckCircle} label="Annonces actives" value={stats.active_listings} />
-        <StatCard icon={FaFlag} label="Signalements" value={stats.reports} />
-        <StatCard icon={FaFlag} label="Signalements en attente" value={stats.pending_reports} />
-        <StatCard icon={FaFileAlt} label="Pages" value={stats.pages} />
+        <StatLinkCard icon={FaUsers} label="Utilisateurs" value={stats.users} href={route('admin.users.index')} />
+        <StatLinkCard icon={FaUsers} label="En attente" value={stats.pending_users} href={`${route('admin.users.index')}?status=en_attente`} />
+        <StatLinkCard icon={FaCheckCircle} label="Certifiés" value={stats.verified_users} href={`${route('admin.users.index')}?status=certifié`} />
+        <StatLinkCard icon={FaListUl} label="En ligne" value={stats.online_users} href={`${route('admin.users.index')}?online=1`} />
+        <StatLinkCard icon={FaHome} label="Annonces" value={stats.listings} href={route('admin.listings.index')} />
+        <StatLinkCard icon={FaHome} label="En attente" value={stats.pending_listings} href={`${route('admin.listings.index')}?status=pending`} />
+        <StatLinkCard icon={FaHome} label="Vendues" value={stats.sold_listings} href={`${route('admin.listings.index')}?status=vendue`} />
+        <StatLinkCard icon={FaCheckCircle} label="Actives" value={stats.active_listings} href={`${route('admin.listings.index')}?status=active`} />
+        <StatLinkCard icon={FaFlag} label="Signalements" value={stats.reports} href={route('admin.reports.index')} />
+        <StatLinkCard icon={FaFlag} label="Signalements en attente" value={stats.pending_reports} href={`${route('admin.reports.index')}?status=pending`} />
+        <StatLinkCard icon={FaFileAlt} label="Pages" value={stats.pages} href={route('admin.pages.index')} />
       </SimpleGrid>
       <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
         <Box bg={cardBg} p={4} rounded="md" shadow="md">

--- a/resources/js/Pages/Admin/Listings/Index.jsx
+++ b/resources/js/Pages/Admin/Listings/Index.jsx
@@ -3,19 +3,21 @@ import { useState, useEffect } from 'react';
 import axios from 'axios';
 import { route } from 'ziggy-js';
 import AdminLayout from '@/Components/Admin/AdminLayout';
+import { usePage } from '@inertiajs/react';
 
-export default function Index() {
+export default function Index({ filters = {} }) {
   const [listings, setListings] = useState([]);
   const [page, setPage] = useState(1);
   const [lastPage, setLastPage] = useState(1);
+  const [status, setStatus] = useState(filters.status || '');
 
   const fetchListings = async () => {
-    const { data } = await axios.get(route('admin.listings.data'), { params: { page } });
+    const { data } = await axios.get(route('admin.listings.data'), { params: { page, status } });
     setListings(data.data);
     setLastPage(data.last_page || 1);
   };
 
-  useEffect(() => { fetchListings(); }, [page]);
+  useEffect(() => { fetchListings(); }, [page, status]);
 
   const updateStatus = async (id, status) => {
     await axios.post(route('admin.listings.status', id), { status });
@@ -24,6 +26,14 @@ export default function Index() {
 
   return (
     <Box>
+      <Flex mb={2} gap={2}>
+        <Select placeholder="Statut" value={status} onChange={(e) => { setStatus(e.target.value); setPage(1); }} w="200px">
+          <option value="active">active</option>
+          <option value="pending">pending</option>
+          <option value="vendue">vendue</option>
+          <option value="archivée">archivée</option>
+        </Select>
+      </Flex>
       <Table variant="striped" colorScheme="gray">
         <Thead>
           <Tr>

--- a/resources/js/Pages/Admin/Reports/Index.jsx
+++ b/resources/js/Pages/Admin/Reports/Index.jsx
@@ -16,18 +16,20 @@ import axios from 'axios';
 import { route } from 'ziggy-js';
 import AdminLayout from '@/Components/Admin/AdminLayout';
 
-export default function Index() {
+export default function Index({ filters = {} }) {
+  const [status, setStatus] = useState(filters.status || '');
+
   const [reports, setReports] = useState([]);
   const [page, setPage] = useState(1);
   const [lastPage, setLastPage] = useState(1);
 
   const load = async () => {
-    const { data } = await axios.get(route('admin.reports.data'), { params: { page } });
+    const { data } = await axios.get(route('admin.reports.data'), { params: { page, status } });
     setReports(data.data);
     setLastPage(data.last_page || 1);
   };
 
-  useEffect(() => { load(); }, [page]);
+  useEffect(() => { load(); }, [page, status]);
 
   const updateStatus = async (id, status) => {
     await axios.post(route('admin.reports.status', id), { status });
@@ -36,6 +38,13 @@ export default function Index() {
 
   return (
     <Box>
+      <Flex mb={2} gap={2} flexWrap="wrap">
+        <Select placeholder="Statut" value={status} onChange={(e) => { setStatus(e.target.value); setPage(1); }} w="200px">
+          <option value="pending">pending</option>
+          <option value="reviewed">reviewed</option>
+          <option value="blocked">blocked</option>
+        </Select>
+      </Flex>
       <Table variant="striped" colorScheme="gray" size="sm">
         <Thead>
           <Tr>

--- a/resources/js/Pages/Admin/Users/Index.jsx
+++ b/resources/js/Pages/Admin/Users/Index.jsx
@@ -19,17 +19,19 @@ import { route } from 'ziggy-js';
 import sweetAlert from '@/libs/sweetalert';
 import AdminLayout from '@/Components/Admin/AdminLayout';
 
-export default function Index() {
+export default function Index({ filters = {} }) {
   const [query, setQuery] = useState('');
   const [page, setPage] = useState(1);
   const [users, setUsers] = useState([]);
   const [lastPage, setLastPage] = useState(1);
   const [sort, setSort] = useState('id');
   const [dir, setDir] = useState('asc');
+  const [status, setStatus] = useState(filters.status || '');
+  const [online, setOnline] = useState(filters.online || false);
 
   const fetchUsers = async () => {
     const { data } = await axios.get(route('admin.users.data'), {
-      params: { search: query, page, sort, dir }
+      params: { search: query, page, sort, dir, status, online }
     });
     setUsers(data.data);
     setLastPage(data.last_page || 1);
@@ -37,7 +39,7 @@ export default function Index() {
 
   useEffect(() => {
     fetchUsers();
-  }, [query, page, sort, dir]);
+  }, [query, page, sort, dir, status, online]);
 
   const handleSort = column => {
     if (sort === column) {
@@ -81,6 +83,33 @@ export default function Index() {
           setPage(1);
         }}
       />
+      <Flex mb={2} gap={2} flexWrap="wrap">
+        <Select
+          placeholder="Certification"
+          value={status}
+          onChange={(e) => {
+            setStatus(e.target.value);
+            setPage(1);
+          }}
+          w="200px"
+        >
+          <option value="en_attente">en_attente</option>
+          <option value="certifié">certifié</option>
+          <option value="refusé">refusé</option>
+          <option value="reupload_requis">reupload_requis</option>
+        </Select>
+        <label>
+          <input
+            type="checkbox"
+            checked={online}
+            onChange={(e) => {
+              setOnline(e.target.checked);
+              setPage(1);
+            }}
+          />
+          Utilisateurs en ligne
+        </label>
+      </Flex>
       <Table variant="striped" colorScheme="gray" size="sm">
         <Thead>
           <Tr>


### PR DESCRIPTION
## Summary
- enhance admin navigation with animated sidebar
- make dashboard stats clickable with animation
- add new statistics (pending users/listings, sold listings, etc.)
- allow filtering users, listings and reports by status
- document admin permissions

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc1ac183883309f536fcc8248c4ea