### PR TITLE
Improve conversation layout

### DIFF
--- a/resources/js/Components/Messages/MessagesLayout.jsx
+++ b/resources/js/Components/Messages/MessagesLayout.jsx
@@ -1,4 +1,5 @@
-import { Box, Flex, VStack, HStack, Avatar, Text, Button, IconButton, Input, useBreakpointValue } from '@chakra-ui/react';
+import { Box, Flex, VStack, HStack, Avatar, Text, Button, IconButton, Input, useBreakpointValue, Image } from '@chakra-ui/react';
+import { InfoIcon } from '@chakra-ui/icons';
 import { FaPaperPlane } from 'react-icons/fa';
 import { useState } from 'react';
 
@@ -19,6 +20,7 @@ function MessageBubble({ message, isMe }) {
       py={2}
       borderRadius="lg"
       maxW="70%"
+      mt={2}
     >
       <Text>{message.body}</Text>
       <Text fontSize="xs" color="gray.500" textAlign="right" mt={1}>
@@ -33,6 +35,12 @@ export default function MessagesLayout({ conversations = [], messages = [], curr
   const [content, setContent] = useState('');
   const flexDir = useBreakpointValue({ base: 'column', md: 'row' });
   const activeConv = conversations.find(c => c.id === activeId);
+  const listingPhoto = activeConv && activeConv.listing ? (() => {
+    const photos = Array.isArray(activeConv.listing.photos)
+      ? activeConv.listing.photos
+      : JSON.parse(activeConv.listing.photos || '[]');
+    return photos[0];
+  })() : null;
 
   const send = () => {
     if (!content) return;
@@ -41,24 +49,22 @@ export default function MessagesLayout({ conversations = [], messages = [], curr
   };
 
   return (
-    <Flex direction={flexDir} h="full" bg="gray.50" borderRadius="md" overflow="hidden">
-      <VStack
-        align="stretch"
-        spacing={0}
-        w={{ base: 'full', md: '300px' }}
-        maxH={{ base: '200px', md: 'auto' }}
-        overflowY="auto"
-        borderRightWidth={{ md: '1px' }}
-        borderColor="gray.200"
-        bg="white"
-      >
+    <Flex direction={flexDir} h="100vh" bg="gray.50" overflow="hidden">
+      <Flex direction="column" w={{ base: 'full', md: '320px' }} bg="white" h="full" borderRightWidth={{ md: '1px' }} borderColor="gray.200">
+        <Box p={4} borderBottomWidth="1px" borderColor="gray.200">
+          <Text fontWeight="bold">Messages</Text>
+        </Box>
+        <VStack align="stretch" spacing={0} overflowY="auto" flex="1">
         {conversations.map(c => (
           <HStack
             key={c.id}
-            p={3}
-            spacing={3}
-            bg={c.id === activeId ? 'orange.100' : 'white'}
-            _hover={{ bg: 'orange.100' }}
+            py={3}
+            px={4}
+            spacing={2}
+            bg={c.id === activeId ? 'gray.100' : 'white'}
+            borderLeftWidth={c.id === activeId ? '4px' : '0'}
+            borderLeftColor={c.id === activeId ? 'brand.500' : 'transparent'}
+            _hover={{ bg: 'gray.100' }}
             cursor="pointer"
             onClick={() => setActiveId(c.id)}
             alignItems="center"
@@ -73,28 +79,45 @@ export default function MessagesLayout({ conversations = [], messages = [], curr
             </Text>
           </HStack>
         ))}
-      </VStack>
+        </VStack>
+      </Flex>
       <Flex direction="column" flex="1" bg="white">
         {activeConv && (
           <>
             <HStack justify="space-between" p={4} borderBottomWidth="1px" borderColor="gray.200">
-              <Box>
-                <Text fontWeight="bold">{activeConv.user.name}</Text>
-                <Text fontSize="sm" color="gray.500">{activeConv.listingTitle}</Text>
+              <Box flex="1">
+                <Text fontWeight="semibold" textAlign="center">{activeConv.user.name}</Text>
               </Box>
+              <IconButton icon={<InfoIcon />} variant="ghost" aria-label="info" />
+            </HStack>
+            <HStack p={4} spacing={4} borderBottomWidth="1px" borderColor="gray.200">
+              {listingPhoto && (
+                <Image src={listingPhoto} boxSize="50px" objectFit="cover" borderRadius="md" />
+              )}
+              <VStack align="start" spacing={0} flex="1">
+                <Text fontWeight="semibold">{activeConv.listingTitle}</Text>
+                <Text fontWeight="bold">{activeConv.listingPrice} €</Text>
+              </VStack>
               <HStack>
-                <Button size="sm" variant="outline" colorScheme="orange">Faire une offre</Button>
-                <Button size="sm" colorScheme="orange">Acheter</Button>
+                <Button size="sm" variant="outline">Faire une offre</Button>
+                <Button size="sm" colorScheme="green">Acheter</Button>
               </HStack>
             </HStack>
-            <VStack flex="1" spacing={3} p={4} overflowY="auto" align="stretch" bg="gray.50">
+            <VStack flex="1" spacing={3} px={4} py={2} overflowY="auto" align="stretch" bg="gray.50">
               {messages.map(m => (
                 <MessageBubble key={m.id} message={m} isMe={m.from_user_id === currentUserId} />
               ))}
             </VStack>
-            <HStack p={4} borderTopWidth="1px" borderColor="gray.200">
-              <Input value={content} onChange={e => setContent(e.target.value)} placeholder="Votre message" />
-              <IconButton icon={<FaPaperPlane />} colorScheme="orange" onClick={send} aria-label="envoyer" />
+            <HStack p={4} borderTopWidth="1px" borderColor="gray.200" position="sticky" bottom="0" bg="white">
+              <Input
+                flex="1"
+                variant="filled"
+                placeholder="Envoyer un message"
+                rounded="full"
+                value={content}
+                onChange={e => setContent(e.target.value)}
+              />
+              <IconButton icon={<FaPaperPlane />} colorScheme="brand" onClick={send} aria-label="envoyer" />
             </HStack>
           </>
         )}


### PR DESCRIPTION
## Summary
- update `MessagesLayout` component styling to mirror Vinted chat layout

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6e4d8eac8330b9baa69739ec98c7