### PR TITLE
Fix meeting status endpoint

### DIFF
--- a/resources/js/Pages/Messages/Index.jsx
+++ b/resources/js/Pages/Messages/Index.jsx
@@ -69,7 +69,7 @@ export default function Index({ conversations: initial = {}, current }) {
   };
 
   const respondMeeting = async (id, status) => {
-    await axios.post(`/meetings/${id}/status`, { status });
+    await axios.post(`/api/meetings/${id}/status`, { status });
     setMeetings(ms => ms.map(m => m.id === id ? { ...m, status } : m));
   };
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,4 +19,6 @@ Route::middleware(['auth:sanctum', 'verified', 'terms', 'certified'])->group(fun
     Route::get('/conversations/{conversation}', [ConversationController::class, 'show'])->middleware('participant');
     Route::post('/conversations/{conversation}/messages', [MessageController::class, 'store'])->middleware(['participant', 'conversation.open']);
     Route::get('/conversations/{conversation}/messages', [MessageController::class, 'index'])->middleware('participant');
+
+    Route::post('/meetings/{meeting}/status', [\App\Http\Controllers\MeetingController::class, 'update'])->middleware(['participant', 'conversation.open']);
 });


### PR DESCRIPTION
## Summary
- allow meeting status updates over API routes
- call API route when responding to a meeting in messages page

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9483a9088330887af76b8ad1b3a8