### PR TITLE
Fix Sanctum stateful domains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+SANCTUM_STATEFUL_DOMAINS=localhost,localhost:5173,127.0.0.1,127.0.0.1:8000,::1
 
 APP_LOCALE=fr
 APP_FALLBACK_LOCALE=en

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Un système de recommandations propose désormais automatiquement des annonces e
 1. Cloner le dépôt puis installer les dépendances PHP et Node.
 2. Copier le fichier `.env.example` vers `.env` puis ajuster la configuration.
 3. Lancer les migrations avec `php artisan migrate`.
+4. Si vous utilisez un serveur front-end distinct (par exemple Vite sur le port 5173),
+   ajoutez ce domaine dans la variable `SANCTUM_STATEFUL_DOMAINS` de votre `.env`
+   afin que l'authentification reste active.
 
 ## Développement
 

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -17,7 +17,7 @@ return [
 
     'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s',
-        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        'localhost,localhost:3000,localhost:5173,127.0.0.1,127.0.0.1:8000,::1',
         Sanctum::currentApplicationUrlWithPort(),
         // Sanctum::currentRequestHost(),
     ))),


### PR DESCRIPTION
## Summary
- allow vite dev server on port 5173 to authenticate
- document SANCTUM_STATEFUL_DOMAINS usage

## Testing
- `php artisan test` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9aed230483308ab41766c47004dc