### PR TITLE
Fix Sanctum stateful domains for Vite

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -17,7 +17,7 @@ return [
 
     'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s',
-        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        'localhost,localhost:5173,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
         Sanctum::currentApplicationUrlWithPort(),
         // Sanctum::currentRequestHost(),
     ))),


### PR DESCRIPTION
## Summary
- allow API calls from the Vite dev server by adding `localhost:5173` to Sanctum's default stateful domains

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9d11dd288330b9eac31289dc394c