### PR TITLE
Fix auth for API messages

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -13,7 +13,7 @@ Route::get('/user', function (Request $request) {
 Route::get('/listings/map', [ListingController::class, 'all']);
 Route::get('/categories', [CategoryController::class, 'index']);
 
-Route::middleware(['auth:sanctum', 'verified', 'terms', 'certified'])->group(function () {
+Route::middleware(['auth', 'verified', 'terms', 'certified'])->group(function () {
     Route::get('/conversations', [ConversationController::class, 'index']);
     Route::post('/conversations', [ConversationController::class, 'store']);
     Route::get('/conversations/{conversation}', [ConversationController::class, 'show'])->middleware('participant');


### PR DESCRIPTION
## Summary
- use session-based `auth` middleware for message routes

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9ea33700833084f0bb6df38b15cc