### PR TITLE
Fetch DVF estimation in frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,11 @@ Le processus de vente est sécurisé par plusieurs documents électroniques :
 
 Les signatures sont stockées en base et peuvent être intégrées dans les PDF générés via l'API ci-dessus.
 
+## Estimation immobilière via API
+
+La page d'accueil affiche une estimation indicative des prix au m². Ces données
+sont désormais récupérées depuis l'API **DVF** fournie par Sogefi :
+<https://www.sogefi-sig.com/geoservices-apis-wms/api-dvf/>. Si l'API n'est pas
+disponible, des valeurs par défaut sont utilisées afin de garantir un rendu
+cohérent de la section d'estimation.
+

--- a/resources/js/Components/Home/PriceEstimationSection.jsx
+++ b/resources/js/Components/Home/PriceEstimationSection.jsx
@@ -1,13 +1,34 @@
 import { Box, Heading, SimpleGrid, VStack, Text } from "@chakra-ui/react";
 import FadeInSection from "../UI/FadeInSection";
+import { useState, useEffect } from "react";
+import axios from "axios";
 
-const data = [
+const fallbackData = [
   { label: "Appartement", value: 3000 },
   { label: "Maison", value: 2500 },
   { label: "Terrain", value: 1500 },
 ];
 
 export default function PriceEstimationSection() {
+  const [data, setData] = useState(fallbackData);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const res = await axios.get(
+          "https://www.sogefi-sig.com/geoservices-apis-wms/api-dvf/"
+        );
+        if (Array.isArray(res.data)) {
+          setData(res.data);
+        }
+      } catch (e) {
+        console.error("Failed to fetch estimation data", e);
+      }
+    }
+
+    fetchData();
+  }, []);
+
   const max = Math.max(...data.map((d) => d.value));
   return (
     <FadeInSection>


### PR DESCRIPTION
## Summary
- fetch price estimation data from Sogefi DVF API
- document the API-based estimation in README

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee93e88708330b407a818e73fdbb8