### PR TITLE
Fix CORS error when fetching price estimation data

### DIFF
--- a/resources/js/Components/Home/PriceEstimationSection.jsx
+++ b/resources/js/Components/Home/PriceEstimationSection.jsx
@@ -16,7 +16,13 @@ export default function PriceEstimationSection() {
     async function fetchData() {
       try {
         const res = await axios.get(
-          "https://www.sogefi-sig.com/geoservices-apis-wms/api-dvf/"
+          "https://www.sogefi-sig.com/geoservices-apis-wms/api-dvf/",
+          {
+            // Disable credentials so the third-party API can respond
+            // with a wildcard Access-Control-Allow-Origin header
+            // without causing CORS errors in browsers.
+            withCredentials: false,
+          }
         );
         if (Array.isArray(res.data)) {
           setData(res.data);


### PR DESCRIPTION
## Summary
- disable credentials when calling the DVF API to avoid CORS failures

## Testing
- `npm run build` *(fails: vite not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eec4dbe388330aeac5e7a4197412b