### PR TITLE
Add visit request card to messages

### DIFF
--- a/resources/js/Components/Meeting/VisitRequestCard.jsx
+++ b/resources/js/Components/Meeting/VisitRequestCard.jsx
@@ -1,0 +1,63 @@
+import { Box, VStack, Text, HStack, Divider, Icon, Button } from '@chakra-ui/react';
+import { FaCalendar, FaMapMarkerAlt, FaUser, FaClock, FaStickyNote } from 'react-icons/fa';
+
+export default function VisitRequestCard({ meeting, listing, seller, onRespond, isBuyer }) {
+  const details = [
+    {
+      label: 'Date proposée',
+      icon: FaCalendar,
+      value: new Date(meeting.scheduled_at).toLocaleString(),
+    },
+    {
+      label: 'Adresse',
+      icon: FaMapMarkerAlt,
+      value: listing.address,
+    },
+    {
+      label: 'Agent',
+      icon: FaUser,
+      value: seller.first_name + ' ' + seller.last_name,
+    },
+    {
+      label: 'Durée estimée',
+      icon: FaClock,
+      value: '30 minutes',
+    },
+  ];
+  if (meeting.agenda) {
+    details.push({ label: 'Notes supplémentaires', icon: FaStickyNote, value: meeting.agenda });
+  }
+
+  return (
+    <Box bg="gray.50" p={5} borderRadius="lg" w="full">
+      <VStack align="stretch" spacing={4} divider={<Divider />}>
+        <Box>
+          <Text fontWeight="semibold" fontSize="lg">Proposition de Visite</Text>
+          <Text fontSize="sm" color="gray.600">
+            Je vous propose une visite pour le bien {listing.title} à l'adresse {listing.address} selon les préférences que vous avez partagées.
+          </Text>
+        </Box>
+        <VStack align="stretch" spacing={3} divider={<Divider />}> 
+          {details.map((d) => (
+            <HStack key={d.label} justify="space-between" align="start">
+              <HStack spacing={2} minW="150px">
+                <Icon as={d.icon} color="gray.500" />
+                <Text fontWeight="medium">{d.label}</Text>
+              </HStack>
+              <Text textAlign="right" flex="1">{d.value}</Text>
+            </HStack>
+          ))}
+        </VStack>
+        {meeting.status === 'pending' && isBuyer && (
+          <HStack justify="flex-end" pt={2} spacing={2}>
+            <Button size="sm" colorScheme="brand" onClick={() => onRespond('accepted')}>Accepter</Button>
+            <Button size="sm" variant="outline" onClick={() => onRespond('declined')}>Refuser</Button>
+          </HStack>
+        )}
+        {meeting.status !== 'pending' && (
+          <Text fontSize="sm" color="gray.600" alignSelf="flex-end">{meeting.status}</Text>
+        )}
+      </VStack>
+    </Box>
+  );
+}

--- a/resources/js/Pages/Messages/Index.jsx
+++ b/resources/js/Pages/Messages/Index.jsx
@@ -4,6 +4,7 @@ import ListingCard from '@/Components/Listing/ListingCard';
 import { usePage } from '@inertiajs/react';
 import { useState, useEffect, useRef } from 'react';
 import VisitScheduler from '@/Components/Meeting/VisitScheduler';
+import VisitRequestCard from '@/Components/Meeting/VisitRequestCard';
 import axios from 'axios';
 import sweetAlert from '@/libs/sweetalert';
 
@@ -167,20 +168,14 @@ export default function Index({ conversations: initial = {}, current }) {
             </HStack>
             <VStack align="stretch" spacing={2} flex="1" overflowY="auto">
               {meetings.map(m => (
-                <Box key={`meeting-${m.id}`} bg="gray.50" borderWidth="1px" borderRadius="md" p={2}>
-                  <HStack justify="space-between">
-                    <Text>Visite le {new Date(m.scheduled_at).toLocaleString()}</Text>
-                    {m.status === 'pending' && auth.user.id === active.buyer_id ? (
-                      <HStack>
-                        <Button size="xs" colorScheme="brand" onClick={() => respondMeeting(m.id, 'accepted')}>Accepter</Button>
-                        <Button size="xs" variant="outline" onClick={() => respondMeeting(m.id, 'declined')}>Refuser</Button>
-                      </HStack>
-                    ) : (
-                      <Text fontSize="sm" color="gray.600">{m.status}</Text>
-                    )}
-                  </HStack>
-                  {m.agenda && <Text fontSize="sm" color="gray.600" mt={2}>{m.agenda}</Text>}
-                </Box>
+                <VisitRequestCard
+                  key={`meeting-${m.id}`}
+                  meeting={m}
+                  listing={active.listing}
+                  seller={active.seller}
+                  isBuyer={auth.user.id === active.buyer_id}
+                  onRespond={status => respondMeeting(m.id, status)}
+                />
               ))}
               {messages.map((m, idx) => {
                 const isMe = m.sender_id === auth.user.id;


### PR DESCRIPTION
## Summary
- add a `VisitRequestCard` component for visit offer details
- display visit requests in message threads with the new card

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f6485c1f4833090e2ca5c0eff4809