### PR TITLE
Add PDF generation logic and HelloSign integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ une **attestation de loyer** signée :
 GET /pdf/attestation/{listing}
 ```
 
+D'autres documents peuvent être générés de la même façon :
+
+```text
+GET /pdf/mandat/{listing}
+GET /pdf/visite/{listing}
+GET /pdf/offre/{listing}
+GET /pdf/compromis/{listing}
+```
+
 Cette route génère un PDF au format proche des attestations de loyer françaises
 en incluant la signature enregistrée.
 

--- a/app/Http/Controllers/ListingController.php
+++ b/app/Http/Controllers/ListingController.php
@@ -225,11 +225,8 @@ class ListingController extends Controller
         $hellosignKey = config('services.hellosign.key');
 
         if ($hellosignKey) {
-            $pdf = Pdf::loadView('pdf.attestation', [
-                'listing' => $listing,
-                'user' => auth()->user(),
-                'signaturePath' => null,
-            ]);
+            $pdfService = new \App\Services\Pdf\DocumentPdfService();
+            $pdf = $pdfService->generate('mandat_exclusif', $listing);
 
             $tmpPath = storage_path('app/tmp/'.uniqid('mandate_').'.pdf');
             if (! is_dir(dirname($tmpPath))) {
@@ -240,8 +237,7 @@ class ListingController extends Controller
             $service = new HelloSignService($hellosignKey);
             $requestId = $service->sendSignatureRequest(
                 $tmpPath,
-                auth()->user()->email,
-                auth()->user()->first_name.' '.auth()->user()->last_name,
+                [auth()->user()->email => auth()->user()->first_name.' '.auth()->user()->last_name],
                 'Signature Mandat',
                 'Veuillez signer le mandat exclusif en pièce jointe.'
             );

--- a/app/Http/Controllers/PdfController.php
+++ b/app/Http/Controllers/PdfController.php
@@ -2,25 +2,67 @@
 namespace App\Http\Controllers;
 
 use App\Models\Listing;
-use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Facades\Storage;
+use App\Services\Pdf\DocumentPdfService;
 
 class PdfController extends Controller
 {
+    protected DocumentPdfService $pdf;
+
+    public function __construct(DocumentPdfService $pdf)
+    {
+        $this->pdf = $pdf;
+    }
+
     public function attestation(Listing $listing)
     {
-        $signature = $listing->documentsToSign()
-            ->where('type', 'mandat_exclusif')
-            ->first()?->signatures()
-            ->where('user_id', auth()->id())
-            ->first();
-
-        $pdf = Pdf::loadView('pdf.attestation', [
-            'listing' => $listing,
-            'user' => auth()->user(),
-            'signaturePath' => $signature ? Storage::disk('public')->path($signature->file_path) : null,
-        ]);
+        [$signaturePath] = $this->signaturePaths($listing, 'mandat_exclusif');
+        $pdf = $this->pdf->generate('attestation', $listing, $signaturePath);
 
         return $pdf->download('attestation-'.$listing->id.'.pdf');
+    }
+
+    public function mandat(Listing $listing)
+    {
+        [$sig1, $sig2] = $this->signaturePaths($listing, 'mandat_exclusif');
+        $pdf = $this->pdf->generate('mandat_exclusif', $listing, $sig1, $sig2);
+
+        return $pdf->download('mandat-'.$listing->id.'.pdf');
+    }
+
+    public function bonDeVisite(Listing $listing)
+    {
+        [$sig1, $sig2] = $this->signaturePaths($listing, 'bon_de_visite');
+        $pdf = $this->pdf->generate('bon_de_visite', $listing, $sig1, $sig2);
+
+        return $pdf->download('bon-de-visite-'.$listing->id.'.pdf');
+    }
+
+    public function offreAchat(Listing $listing)
+    {
+        [$sig1, $sig2] = $this->signaturePaths($listing, 'offre_achat');
+        $pdf = $this->pdf->generate('offre_achat', $listing, $sig1, $sig2);
+
+        return $pdf->download('offre-achat-'.$listing->id.'.pdf');
+    }
+
+    public function compromis(Listing $listing)
+    {
+        [$sig1, $sig2] = $this->signaturePaths($listing, 'compromis_de_vente');
+        $pdf = $this->pdf->generate('compromis_de_vente', $listing, $sig1, $sig2);
+
+        return $pdf->download('compromis-'.$listing->id.'.pdf');
+    }
+
+    private function signaturePaths(Listing $listing, string $type): array
+    {
+        $doc = $listing->documentsToSign()->where('type', $type)->first();
+        $sig1 = $doc?->signatures()->first();
+        $sig2 = $doc?->signatures()->skip(1)->first();
+
+        $path1 = $sig1 && $sig1->file_path ? Storage::disk('public')->path($sig1->file_path) : null;
+        $path2 = $sig2 && $sig2->file_path ? Storage::disk('public')->path($sig2->file_path) : null;
+
+        return [$path1, $path2];
     }
 }

--- a/app/Services/Pdf/DocumentPdfService.php
+++ b/app/Services/Pdf/DocumentPdfService.php
@@ -1,0 +1,19 @@
+<?php
+namespace App\Services\Pdf;
+
+use App\Models\Listing;
+use Barryvdh\DomPDF\Facade\Pdf;
+
+class DocumentPdfService
+{
+    public function generate(string $type, Listing $listing, ?string $signaturePath = null, ?string $otherSignaturePath = null)
+    {
+        $view = 'pdf.' . $type;
+        return Pdf::loadView($view, [
+            'listing' => $listing,
+            'user' => $listing->user,
+            'signaturePath' => $signaturePath,
+            'otherSignaturePath' => $otherSignaturePath,
+        ]);
+    }
+}

--- a/app/Services/Signature/DocumentSignatureService.php
+++ b/app/Services/Signature/DocumentSignatureService.php
@@ -1,0 +1,35 @@
+<?php
+namespace App\Services\Signature;
+
+use App\Models\Listing;
+use App\Services\Pdf\DocumentPdfService;
+
+class DocumentSignatureService
+{
+    protected ?HelloSignService $service;
+    protected DocumentPdfService $pdfService;
+
+    public function __construct(DocumentPdfService $pdfService)
+    {
+        $key = config('services.hellosign.key');
+        $this->service = $key ? new HelloSignService($key) : null;
+        $this->pdfService = $pdfService;
+    }
+
+    public function sendForSignature(string $type, Listing $listing, array $signers, string $subject)
+    {
+        if (! $this->service) {
+            return null;
+        }
+
+        $pdf = $this->pdfService->generate($type, $listing);
+        $tmpPath = storage_path('app/tmp/'.uniqid($type.'_').'.pdf');
+        if (! is_dir(dirname($tmpPath))) {
+            mkdir(dirname($tmpPath), 0755, true);
+        }
+        file_put_contents($tmpPath, $pdf->output());
+
+        $requestId = $this->service->sendSignatureRequest($tmpPath, $signers, $subject, '');
+        return $requestId;
+    }
+}

--- a/app/Services/Signature/HelloSignService.php
+++ b/app/Services/Signature/HelloSignService.php
@@ -18,29 +18,30 @@ class HelloSignService
      * Send a PDF for signing using HelloSign.
      *
      * @param string $filePath Path to the PDF that should be signed.
-     * @param string $signerEmail Email address of the signer.
-     * @param string $signerName Name of the signer.
-     * @param string $subject Subject of the email sent to the signer.
-     * @param string $message Optional message to include in the email.
+     * @param array  $signers  Array of [email => name] pairs.
+     * @param string $subject  Subject of the email sent to signers.
+     * @param string $message  Optional message to include in the email.
      * @return string The signature request ID.
      */
     public function sendSignatureRequest(
         string $filePath,
-        string $signerEmail,
-        string $signerName,
+        array $signers,
         string $subject = 'Please sign the attached document',
         string $message = ''
     ): string {
-        $signer = new SubSignatureRequestSigner([
-            'email_address' => $signerEmail,
-            'name' => $signerName,
-        ]);
+        $signerObjects = [];
+        foreach ($signers as $email => $name) {
+            $signerObjects[] = new SubSignatureRequestSigner([
+                'email_address' => $email,
+                'name' => $name,
+            ]);
+        }
 
         $request = new SignatureRequestSendRequest([
             'title' => $subject,
             'subject' => $subject,
             'message' => $message,
-            'signers' => [$signer],
+            'signers' => $signerObjects,
             'file_path' => [$filePath],
         ]);
 

--- a/resources/views/pdf/bon_de_visite.blade.php
+++ b/resources/views/pdf/bon_de_visite.blade.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: sans-serif; font-size: 14px; }
+        h1 { text-align: center; font-size: 20px; margin-bottom: 20px; }
+        .section { margin-bottom: 10px; }
+        .signatures { margin-top: 40px; display: flex; justify-content: space-between; }
+        .signature { width: 45%; text-align: center; }
+        .signature img { max-height: 80px; }
+        .signature .line { border-top: 1px solid #000; margin-top: 60px; }
+    </style>
+</head>
+<body>
+    <h1>Bon de visite</h1>
+    <p>Ce document atteste que le visiteur a pris connaissance du bien : <strong>{{ \$listing->title }}</strong> situé à {{ \$listing->address }}.</p>
+    <p>La présente visite n'engage aucune des parties sur la vente du bien.</p>
+    <div class="signatures">
+        <div class="signature">
+            @if(\$signaturePath)
+                <img src="{{ \$signaturePath }}" alt="Signature visiteur">
+            @endif
+            <div class="line">Signature visiteur</div>
+        </div>
+        <div class="signature">
+            @if(\$otherSignaturePath)
+                <img src="{{ \$otherSignaturePath }}" alt="Signature agence">
+            @endif
+            <div class="line">Signature agence</div>
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/pdf/compromis_de_vente.blade.php
+++ b/resources/views/pdf/compromis_de_vente.blade.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: sans-serif; font-size: 14px; }
+        h1 { text-align: center; font-size: 20px; margin-bottom: 20px; }
+        .section { margin-bottom: 10px; }
+        .signatures { margin-top: 40px; display: flex; justify-content: space-between; }
+        .signature { width: 45%; text-align: center; }
+        .signature img { max-height: 80px; }
+        .signature .line { border-top: 1px solid #000; margin-top: 60px; }
+    </style>
+</head>
+<body>
+    <h1>Compromis de vente</h1>
+    <p>Les parties s'engagent à conclure la vente du bien <strong>{{ \$listing->title }}</strong> situé à {{ \$listing->address }} aux conditions indiquées.</p>
+    <p>Le présent compromis précise les obligations de chacune des parties.</p>
+    <div class="signatures">
+        <div class="signature">
+            @if(\$signaturePath)
+                <img src="{{ \$signaturePath }}" alt="Signature acheteur">
+            @endif
+            <div class="line">Signature acheteur</div>
+        </div>
+        <div class="signature">
+            @if(\$otherSignaturePath)
+                <img src="{{ \$otherSignaturePath }}" alt="Signature vendeur">
+            @endif
+            <div class="line">Signature vendeur</div>
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/pdf/mandat_exclusif.blade.php
+++ b/resources/views/pdf/mandat_exclusif.blade.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: sans-serif; font-size: 14px; }
+        h1 { text-align: center; font-size: 20px; margin-bottom: 20px; }
+        .section { margin-bottom: 10px; }
+        .signatures { margin-top: 40px; display: flex; justify-content: space-between; }
+        .signature { width: 45%; text-align: center; }
+        .signature img { max-height: 80px; }
+        .signature .line { border-top: 1px solid #000; margin-top: 60px; }
+    </style>
+</head>
+<body>
+    <h1>Mandat de vente exclusif</h1>
+    <p>Le proprietaire confie a l'agence la mise en vente du bien suivant : <strong>{{ \$listing->title }}</strong> situe a {{ \$listing->address }}.</p>
+    <p>Les conditions de vente sont detaillees dans le present mandat.</p>
+    <div class="signatures">
+        <div class="signature">
+            @if(\$signaturePath)
+                <img src="{{ \$signaturePath }}" alt="Signature proprietaire">
+            @endif
+            <div class="line">Signature proprietaire</div>
+        </div>
+        <div class="signature">
+            @if(\$otherSignaturePath)
+                <img src="{{ \$otherSignaturePath }}" alt="Signature agence">
+            @endif
+            <div class="line">Signature agence</div>
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/pdf/offre_achat.blade.php
+++ b/resources/views/pdf/offre_achat.blade.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: sans-serif; font-size: 14px; }
+        h1 { text-align: center; font-size: 20px; margin-bottom: 20px; }
+        .section { margin-bottom: 10px; }
+        .signatures { margin-top: 40px; display: flex; justify-content: space-between; }
+        .signature { width: 45%; text-align: center; }
+        .signature img { max-height: 80px; }
+        .signature .line { border-top: 1px solid #000; margin-top: 60px; }
+    </style>
+</head>
+<body>
+    <h1>Offre d'achat</h1>
+    <p>L'acheteur propose d'acquérir le bien <strong>{{ \$listing->title }}</strong> situé à {{ \$listing->address }} aux conditions précisées.</p>
+    <p>Cette offre est valable pendant la durée indiquée ci-dessous.</p>
+    <div class="signatures">
+        <div class="signature">
+            @if(\$signaturePath)
+                <img src="{{ \$signaturePath }}" alt="Signature acheteur">
+            @endif
+            <div class="line">Signature acheteur</div>
+        </div>
+        <div class="signature">
+            @if(\$otherSignaturePath)
+                <img src="{{ \$otherSignaturePath }}" alt="Signature vendeur">
+            @endif
+            <div class="line">Signature vendeur</div>
+        </div>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -173,6 +173,10 @@ Route::middleware(['auth'])->group(function () {
 
     // Génération d'une attestation de loyer au format PDF
     Route::get('/pdf/attestation/{listing}', [\App\Http\Controllers\PdfController::class, 'attestation'])->name('pdf.attestation');
+    Route::get('/pdf/mandat/{listing}', [\App\Http\Controllers\PdfController::class, 'mandat'])->name('pdf.mandat');
+    Route::get('/pdf/visite/{listing}', [\App\Http\Controllers\PdfController::class, 'bonDeVisite'])->name('pdf.visite');
+    Route::get('/pdf/offre/{listing}', [\App\Http\Controllers\PdfController::class, 'offreAchat'])->name('pdf.offre');
+    Route::get('/pdf/compromis/{listing}', [\App\Http\Controllers\PdfController::class, 'compromis'])->name('pdf.compromis');
 });
 
 Route::middleware(['auth', 'verified', 'terms', 'certified'])->group(function () {


### PR DESCRIPTION
## Summary
- create DocumentPdfService to build PDFs from Blade views
- add DocumentSignatureService and extend HelloSignService for multiple signers
- create PDF templates for mandate, visit sheet, offer and compromise
- expand PdfController to download all these documents
- expose new routes for each PDF
- update README with the new endpoints

## Testing
- `php artisan test` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff78399148330b3500dc765cabf5e