### PR TITLE
Switch to Snappy PDF and add admin document approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Assignez ce rôle à un utilisateur via la relation `roles` pour lui donner acc�
 ## Signature électronique et génération de PDF
 
 Le projet s'appuie sur le composant React **react-signature-canvas** pour
-capturer les signatures. Pour générer des PDF, installez l'extension gratuite
-`barryvdh/laravel-dompdf` :
+capturer les signatures. Pour générer des PDF, installez l'extension
+`barryvdh/laravel-snappy` :
 
 ```bash
-composer require barryvdh/laravel-dompdf
+composer require barryvdh/laravel-snappy
 composer require dropbox/sign
 ```
 
@@ -78,6 +78,8 @@ Le processus de vente est sécurisé par plusieurs documents électroniques :
 4. **Compromis de vente** puis **acte définitif** : les deux parties finalisent la vente.
 
 Les signatures sont stockées en base et peuvent être intégrées dans les PDF générés via l'API ci-dessus.
+
+Les administrateurs peuvent superviser ces documents depuis le tableau de bord à l'adresse `/admin/documents` et approuver chaque fichier une fois vérifié.
 
 ## Estimation immobilière via API
 

--- a/app/Http/Controllers/Admin/DocumentController.php
+++ b/app/Http/Controllers/Admin/DocumentController.php
@@ -1,0 +1,44 @@
+<?php
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\DocumentToSign;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Inertia\Inertia;
+
+class DocumentController extends Controller
+{
+    public function index(Request $request)
+    {
+        return Inertia::render('Admin/Documents/Index');
+    }
+
+    public function data(Request $request)
+    {
+        $query = DocumentToSign::with('listing:id,title', 'approvedBy:id,first_name,last_name');
+
+        if ($type = $request->input('type')) {
+            $query->where('type', $type);
+        }
+
+        $sort = $request->input('sort', 'created_at');
+        $dir = $request->input('dir', 'desc');
+        $query->orderBy($sort, $dir);
+
+        $perPage = (int) $request->input('per_page', 10);
+
+        return $query->paginate($perPage);
+    }
+
+    public function approve(DocumentToSign $document)
+    {
+        $document->update([
+            'approved_by' => Auth::id(),
+            'approved_at' => now(),
+            'status' => 'approuve'
+        ]);
+
+        return response()->json(['message' => 'Document approuvé']);
+    }
+}

--- a/app/Http/Controllers/ListingController.php
+++ b/app/Http/Controllers/ListingController.php
@@ -12,7 +12,6 @@ use Inertia\Inertia;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
-use Barryvdh\DomPDF\Facade\Pdf;
 use App\Services\Signature\HelloSignService;
 
 class ListingController extends Controller

--- a/app/Models/DocumentToSign.php
+++ b/app/Models/DocumentToSign.php
@@ -5,10 +5,14 @@ use Illuminate\Database\Eloquent\Model;
 
 class DocumentToSign extends Model
 {
-    protected $fillable = ['listing_id', 'type', 'status'];
+    protected $fillable = ['listing_id', 'type', 'status', 'approved_at', 'approved_by'];
 
     public function listing() {
         return $this->belongsTo(Listing::class);
+    }
+
+    public function approvedBy() {
+        return $this->belongsTo(User::class, 'approved_by');
     }
 
     public function signatures() {

--- a/app/Services/Pdf/DocumentPdfService.php
+++ b/app/Services/Pdf/DocumentPdfService.php
@@ -2,14 +2,14 @@
 namespace App\Services\Pdf;
 
 use App\Models\Listing;
-use Barryvdh\DomPDF\Facade\Pdf;
+use Barryvdh\Snappy\Facades\SnappyPdf;
 
 class DocumentPdfService
 {
     public function generate(string $type, Listing $listing, ?string $signaturePath = null, ?string $otherSignaturePath = null)
     {
         $view = 'pdf.' . $type;
-        return Pdf::loadView($view, [
+        return SnappyPdf::loadView($view, [
             'listing' => $listing,
             'user' => $listing->user,
             'signaturePath' => $signaturePath,

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.10.1",
         "tightenco/ziggy": "^2.5",
-        "barryvdh/laravel-dompdf": "^2.0",
+        "barryvdh/laravel-snappy": "^2.0",
         "dropbox/sign": "^1.3"
     },
     "require-dev": {

--- a/database/migrations/2025_07_05_000001_add_admin_approval_to_documents_to_sign_table.php
+++ b/database/migrations/2025_07_05_000001_add_admin_approval_to_documents_to_sign_table.php
@@ -1,0 +1,23 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('documents_to_sign', function (Blueprint $table) {
+            $table->foreignId('approved_by')->nullable()->after('status')->constrained('users')->nullOnDelete();
+            $table->timestamp('approved_at')->nullable()->after('approved_by');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('documents_to_sign', function (Blueprint $table) {
+            $table->dropForeign(['approved_by']);
+            $table->dropColumn('approved_by');
+            $table->dropColumn('approved_at');
+        });
+    }
+};

--- a/resources/js/Components/Admin/AdminLayout.jsx
+++ b/resources/js/Components/Admin/AdminLayout.jsx
@@ -59,6 +59,11 @@ export default function AdminLayout({ children }) {
             <Icon as={FaCalendarAlt} />
             <Text>Visites</Text>
           </ChakraLink>
+          <ChakraLink as={Link} href="/admin/documents" display="flex" alignItems="center" gap={2}
+            >
+            <Icon as={FaFileAlt} />
+            <Text>Documents</Text>
+          </ChakraLink>
         </Flex>
       </Box>
       </Slide>

--- a/resources/js/Pages/Admin/Documents/Index.jsx
+++ b/resources/js/Pages/Admin/Documents/Index.jsx
@@ -1,0 +1,81 @@
+import {
+  Box,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Button,
+  Flex,
+  Text
+} from '@chakra-ui/react';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { route } from 'ziggy-js';
+import AdminLayout from '@/Components/Admin/AdminLayout';
+import sweetAlert from '@/libs/sweetalert';
+
+export default function Index() {
+  const [documents, setDocuments] = useState([]);
+  const [page, setPage] = useState(1);
+  const [lastPage, setLastPage] = useState(1);
+
+  const fetchDocuments = async () => {
+    const { data } = await axios.get(route('admin.documents.data'), {
+      params: { page }
+    });
+    setDocuments(data.data);
+    setLastPage(data.last_page || 1);
+  };
+
+  useEffect(() => {
+    fetchDocuments();
+  }, [page]);
+
+  const approve = async id => {
+    await axios.post(route('admin.documents.approve', id));
+    sweetAlert('Document approuvé', 'success');
+    fetchDocuments();
+  };
+
+  return (
+    <Box>
+      <Table size="sm">
+        <Thead>
+          <Tr>
+            <Th>ID</Th>
+            <Th>Annonce</Th>
+            <Th>Type</Th>
+            <Th>Status</Th>
+            <Th>Approuvé par</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {documents.map(d => (
+            <Tr key={d.id}>
+              <Td>{d.id}</Td>
+              <Td>{d.listing?.title}</Td>
+              <Td>{d.type}</Td>
+              <Td>{d.status}</Td>
+              <Td>{d.approved_by ? `${d.approved_by.first_name} ${d.approved_by.last_name}` : '-'}</Td>
+              <Td>
+                {!d.approved_at && (
+                  <Button size="xs" onClick={() => approve(d.id)}>Approuver</Button>
+                )}
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+      <Flex mt={4} justify="space-between" align="center">
+        <Button onClick={() => setPage(p => Math.max(1, p - 1))} isDisabled={page === 1}>Précédent</Button>
+        <Text>{page} / {lastPage}</Text>
+        <Button onClick={() => setPage(p => Math.min(lastPage, p + 1))} isDisabled={page === lastPage}>Suivant</Button>
+      </Flex>
+    </Box>
+  );
+}
+
+Index.layout = page => <AdminLayout>{page}</AdminLayout>;

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,6 +94,10 @@ Route::middleware(['auth', 'verified', 'terms', EnsureIsAdmin::class])
 
         Route::get('/visits', [AdminVisitController::class, 'index'])->name('visits.index');
         Route::get('/visits/data', [AdminVisitController::class, 'data'])->name('visits.data');
+
+        Route::get('/documents', [\App\Http\Controllers\Admin\DocumentController::class, 'index'])->name('documents.index');
+        Route::get('/documents/data', [\App\Http\Controllers\Admin\DocumentController::class, 'data'])->name('documents.data');
+        Route::post('/documents/{document}/approve', [\App\Http\Controllers\Admin\DocumentController::class, 'approve'])->name('documents.approve');
     });
 Route::middleware(['auth', 'verified', 'terms', 'certified'])->group(function () {
     Route::resource('listings', ListingController::class)->except(['show']);


### PR DESCRIPTION
## Summary
- replace DOMPDF with Snappy for PDF generation
- add admin document approval routes and controller
- create migration for document approval tracking
- add admin view to approve documents
- show Documents link in admin layout
- update README for Snappy usage and admin supervision

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ffad4a1bc8330b2259f45935afacd