### PR TITLE
Add messages dropdown and live polling

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use Illuminate\Http\Request;
 use Inertia\Middleware;
+use App\Models\Message;
 
 class HandleInertiaRequests extends Middleware
 {
@@ -44,6 +45,15 @@ class HandleInertiaRequests extends Middleware
             ],
             'unreadNotifications' => $request->user()
                 ? $request->user()->unreadNotifications()->count()
+                : 0,
+            'unreadMessages' => $request->user()
+                ? Message::whereHas('conversation', function ($q) use ($request) {
+                    $q->where('buyer_id', $request->user()->id)
+                      ->orWhere('seller_id', $request->user()->id);
+                })
+                    ->where('sender_id', '!=', $request->user()->id)
+                    ->where('is_read', false)
+                    ->count()
                 : 0,
             'flash' => [
                 'success' => $request->session()->get('success'),

--- a/resources/js/Components/Layout/Navbar.jsx
+++ b/resources/js/Components/Layout/Navbar.jsx
@@ -19,6 +19,7 @@ import { HamburgerIcon } from "@chakra-ui/icons";
 import { useRecoilState } from 'recoil';
 import modeAtom from '@/state/modeAtom';
 import NotificationBell from "../UI/NotificationBell";
+import MessagesBell from "../UI/MessagesBell";
 import { Link, usePage } from "@inertiajs/react";
 import { route } from "ziggy-js";
 
@@ -86,6 +87,7 @@ export default function Navbar() {
                     {mode === 'buyer' ? 'Mode vendeur' : 'Mode acheteur'}
                 </Button>
                 <NotificationBell />
+                <MessagesBell />
                 <Menu>
                     <MenuButton as={Button} variant="ghost" rightIcon={<HamburgerIcon />}>
                         <Avatar size="sm" name={auth.user.first_name} />

--- a/resources/js/Components/UI/MessagesBell.jsx
+++ b/resources/js/Components/UI/MessagesBell.jsx
@@ -1,0 +1,67 @@
+import { Badge, Menu, MenuButton, MenuList, MenuItem, IconButton, Avatar, HStack, Text } from '@chakra-ui/react';
+import { FaEnvelope } from 'react-icons/fa';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Link, usePage } from '@inertiajs/react';
+
+export default function MessagesBell() {
+  const { auth, unreadMessages = 0 } = usePage().props;
+  const [conversations, setConversations] = useState([]);
+
+  const loadConversations = async () => {
+    try {
+      const res = await axios.get('/conversations?limit=5');
+      const data = res.data.data || [];
+      setConversations(data);
+    } catch (e) {}
+  };
+
+  useEffect(() => {
+    loadConversations();
+    const interval = setInterval(loadConversations, 10000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const unreadCount =
+    conversations.reduce((sum, c) => sum + (c.unread_count || 0), 0) || unreadMessages;
+
+  const getPartner = (conv) => {
+    return conv.seller_id === auth.user.id ? conv.buyer : conv.seller;
+  };
+
+  return (
+    <Menu>
+      <MenuButton as={IconButton} variant="ghost" icon={<FaEnvelope />} aria-label="Messages" position="relative" mr={2}>
+        {unreadCount > 0 && (
+          <Badge position="absolute" top="0" right="0" bg="brand.500" color="white" borderRadius="full">
+            {unreadCount}
+          </Badge>
+        )}
+      </MenuButton>
+      <MenuList w={{ base: '100%', sm: '300px' }}>
+        {conversations.length === 0 ? (
+          <MenuItem>Aucune conversation</MenuItem>
+        ) : (
+          conversations.map((c) => {
+            const partner = getPartner(c);
+            return (
+              <MenuItem
+                key={c.id}
+                as={Link}
+                href={`/messages?conversation=${c.id}`}
+                bg={c.unread_count > 0 ? 'gray.100' : 'white'}
+                _hover={{ bg: c.unread_count > 0 ? 'gray.200' : 'gray.50' }}
+              >
+                <HStack align="start" spacing={3} w="100%">
+                  <Avatar size="sm" name={`${partner.first_name} ${partner.last_name}`} />
+                  <Text flex="1" noOfLines={1}>{c.subject || c.listing.title}</Text>
+                  {c.unread_count > 0 && <Badge colorScheme="brand">{c.unread_count}</Badge>}
+                </HStack>
+              </MenuItem>
+            );
+          })
+        )}
+      </MenuList>
+    </Menu>
+  );
+}

--- a/resources/js/Pages/Messages/Index.jsx
+++ b/resources/js/Pages/Messages/Index.jsx
@@ -108,6 +108,27 @@ export default function Index({ conversations: initial = {}, current }) {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
+  useEffect(() => {
+    if (!active) return;
+    const fetchNew = async () => {
+      try {
+        const res = await axios.get(`/conversations/${active.id}/messages`);
+        const data = res.data || [];
+        setMessages(ms => {
+          if (ms.length !== data.length || (ms[ms.length - 1]?.id !== data[data.length - 1]?.id)) {
+            return data;
+          }
+          return ms;
+        });
+        if (data.some(m => !m.is_read && m.sender_id !== auth.user.id)) {
+          await axios.post(`/conversations/${active.id}/read`);
+        }
+      } catch (e) {}
+    };
+    const interval = setInterval(fetchNew, 5000);
+    return () => clearInterval(interval);
+  }, [active]);
+
   return (
     <HStack align="start" spacing={6}>
       <VStack align="stretch" w={{ base: 'full', md: '250px' }} spacing={1}>


### PR DESCRIPTION
## Summary
- show unread messages count in shared Inertia props
- add MessagesBell component with unread badge and dropdown
- display MessagesBell next to notifications
- poll active conversation for new messages

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68701b40c91483309987a7e788ac031b