### PR TITLE
Implement visit confirmation workflow

### DIFF
--- a/app/Http/Controllers/ConversationController.php
+++ b/app/Http/Controllers/ConversationController.php
@@ -119,6 +119,15 @@ class ConversationController extends Controller
             },
         ]);
 
+        $visit = \App\Models\Visit::where('listing_id', $conversation->listing_id)
+            ->where('user_id', $conversation->buyer_id)
+            ->orderBy('visit_datetime', 'desc')
+            ->first();
+
+        if ($visit) {
+            $conversation->setRelation('visit', $visit);
+        }
+
         return response()->json($conversation);
     }
 }

--- a/app/Http/Controllers/VisitController.php
+++ b/app/Http/Controllers/VisitController.php
@@ -27,4 +27,62 @@ class VisitController extends Controller
             'as_seller' => $sellerVisits,
         ]);
     }
+
+    public function markDone(Visit $visit)
+    {
+        if ($visit->user_id !== Auth::id()) {
+            abort(403);
+        }
+
+        if ($visit->visit_datetime->isFuture()) {
+            return response()->json(['message' => 'La visite n\'est pas encore passée'], 400);
+        }
+
+        $visit->update(['buyer_confirmed_at' => now()]);
+
+        $conversation = \App\Models\Conversation::where('listing_id', $visit->listing_id)
+            ->where('buyer_id', $visit->user_id)
+            ->first();
+
+        if ($conversation) {
+            \App\Models\Message::create([
+                'conversation_id' => $conversation->id,
+                'sender_id' => Auth::id(),
+                'content' => 'L\'acheteur a confirmé avoir effectué la visite.',
+                'is_read' => false,
+            ]);
+        }
+
+        return response()->json(['status' => 'done']);
+    }
+
+    public function sellerConfirm(Visit $visit)
+    {
+        if ($visit->listing->user_id !== Auth::id()) {
+            abort(403);
+        }
+
+        request()->validate(['comment' => 'nullable|string']);
+
+        $visit->update([
+            'seller_confirmed_at' => now(),
+            'seller_comment' => request('comment'),
+            'status' => 'confirmee',
+        ]);
+
+        $conversation = \App\Models\Conversation::where('listing_id', $visit->listing_id)
+            ->where('buyer_id', $visit->user_id)
+            ->first();
+
+        if ($conversation) {
+            \App\Models\Message::create([
+                'conversation_id' => $conversation->id,
+                'sender_id' => Auth::id(),
+                'content' => 'Le vendeur a confirmé la visite : '.(request('comment') ?? ''),
+                'is_read' => false,
+            ]);
+        }
+
+        return response()->json(['status' => 'confirmed']);
+    }
 }

--- a/app/Models/Visit.php
+++ b/app/Models/Visit.php
@@ -5,7 +5,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class Visit extends Model
 {
-    protected $fillable = ['listing_id', 'user_id', 'visit_datetime', 'status', 'mode'];
+    protected $fillable = ['listing_id', 'user_id', 'visit_datetime', 'status', 'mode', 'buyer_confirmed_at', 'seller_confirmed_at', 'seller_comment'];
+
+    protected $casts = [
+        'visit_datetime' => 'datetime',
+        'buyer_confirmed_at' => 'datetime',
+        'seller_confirmed_at' => 'datetime',
+    ];
 
     public function listing() {
         return $this->belongsTo(Listing::class);

--- a/database/migrations/2025_07_15_203500_add_confirmation_to_visits_table.php
+++ b/database/migrations/2025_07_15_203500_add_confirmation_to_visits_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('visits', function (Blueprint $table) {
+            $table->timestamp('buyer_confirmed_at')->nullable()->after('mode');
+            $table->timestamp('seller_confirmed_at')->nullable()->after('buyer_confirmed_at');
+            $table->text('seller_comment')->nullable()->after('seller_confirmed_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('visits', function (Blueprint $table) {
+            $table->dropColumn(['buyer_confirmed_at', 'seller_confirmed_at', 'seller_comment']);
+        });
+    }
+};

--- a/resources/js/Components/Meeting/VisitDoneModal.jsx
+++ b/resources/js/Components/Meeting/VisitDoneModal.jsx
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+import {
+  Button,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  useDisclosure,
+  Text,
+} from '@chakra-ui/react';
+import axios from 'axios';
+
+export default function VisitDoneModal({ visit, onConfirmed }) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  useEffect(() => {
+    if (!visit) return;
+    const visitTime = new Date(visit.visit_datetime);
+    if (!visit.buyer_confirmed_at && Date.now() >= visitTime.getTime()) {
+      onOpen();
+    }
+  }, [visit]);
+
+  const confirm = async () => {
+    await axios.post(`/visits/${visit.id}/done`);
+    onClose();
+    if (onConfirmed) onConfirmed();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Confirmer la visite</ModalHeader>
+        <ModalBody>
+          <Text>Confirmez-vous avoir effectué la visite du {new Date(visit.visit_datetime).toLocaleString()} ?</Text>
+        </ModalBody>
+        <ModalFooter>
+          <Button mr={3} onClick={onClose}>Annuler</Button>
+          <Button colorScheme="brand" onClick={confirm}>Confirmer</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/resources/js/Components/Meeting/VisitSellerConfirmModal.jsx
+++ b/resources/js/Components/Meeting/VisitSellerConfirmModal.jsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import {
+  Button,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  useDisclosure,
+  Textarea,
+  Text,
+} from '@chakra-ui/react';
+import axios from 'axios';
+
+export default function VisitSellerConfirmModal({ visit, onConfirmed }) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [comment, setComment] = useState('');
+
+  useEffect(() => {
+    if (!visit) return;
+    if (visit.buyer_confirmed_at && !visit.seller_confirmed_at) {
+      onOpen();
+    }
+  }, [visit]);
+
+  const confirm = async () => {
+    await axios.post(`/visits/${visit.id}/confirm`, { comment });
+    onClose();
+    setComment('');
+    if (onConfirmed) onConfirmed();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Confirmer la visite</ModalHeader>
+        <ModalBody>
+          <Text>Validez la visite effectuée le {new Date(visit.visit_datetime).toLocaleString()}.</Text>
+          <Textarea mt={4} placeholder="Commentaire" value={comment} onChange={e => setComment(e.target.value)} />
+        </ModalBody>
+        <ModalFooter>
+          <Button mr={3} onClick={onClose}>Annuler</Button>
+          <Button colorScheme="brand" onClick={confirm}>Confirmer</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/resources/js/Pages/Messages/Index.jsx
+++ b/resources/js/Pages/Messages/Index.jsx
@@ -5,6 +5,8 @@ import { usePage } from '@inertiajs/react';
 import { useState, useEffect, useRef } from 'react';
 import VisitScheduler from '@/Components/Meeting/VisitScheduler';
 import VisitRequestCard from '@/Components/Meeting/VisitRequestCard';
+import VisitDoneModal from '@/Components/Meeting/VisitDoneModal';
+import VisitSellerConfirmModal from '@/Components/Meeting/VisitSellerConfirmModal';
 import axios from 'axios';
 import sweetAlert from '@/libs/sweetalert';
 
@@ -17,6 +19,7 @@ export default function Index({ conversations: initial = {}, current }) {
   const [conversations, setConversations] = useState(initial.data || []);
   const [nextPage, setNextPage] = useState(initial.next_page_url);
   const [meetings, setMeetings] = useState([]);
+  const [visit, setVisit] = useState(null);
   const reportUser = async () => {
     if (!partner) return;
     await axios.post('/reports', {
@@ -36,6 +39,7 @@ export default function Index({ conversations: initial = {}, current }) {
       const messagesRes = await axios.get(`/conversations/${conv.id}/messages`);
       setMessages(messagesRes.data);
       setMeetings(res.data.meetings || []);
+      setVisit(res.data.visit || null);
 
       const other = res.data.seller_id === auth.user.id ? res.data.buyer : res.data.seller;
       setPartner(other);
@@ -247,6 +251,12 @@ export default function Index({ conversations: initial = {}, current }) {
           <Text>Aucune conversation</Text>
         )}
       </Box>
+      {active && visit && auth.user.id === active.buyer_id && (
+        <VisitDoneModal visit={visit} onConfirmed={() => loadConversation(active)} />
+      )}
+      {active && visit && auth.user.id === active.seller_id && (
+        <VisitSellerConfirmModal visit={visit} onConfirmed={() => loadConversation(active)} />
+      )}
     </HStack>
   );
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -122,6 +122,8 @@ Route::middleware(['auth', 'verified', 'terms', 'certified'])->group(function ()
     Route::post('/conversations/{conversation}/meetings', [MeetingController::class, 'store'])->middleware(['participant', 'conversation.open']);
     Route::post('/meetings/{meeting}/status', [MeetingController::class, 'update'])->middleware(['participant', 'conversation.open']);
     Route::get('/visits', [VisitController::class, 'index']);
+    Route::post('/visits/{visit}/done', [VisitController::class, 'markDone']);
+    Route::post('/visits/{visit}/confirm', [VisitController::class, 'sellerConfirm']);
     Route::post('/messages/{message}/read', [MessageController::class, 'markAsRead']);
 
     Route::get('/notifications', [NotificationController::class, 'index']);


### PR DESCRIPTION
## Summary
- add buyer & seller confirmation columns for visits
- allow marking visits done and confirming them
- load latest visit in conversations
- show modals to confirm visits after they occur
- cast new fields in Visit model

## Testing
- `php artisan test` *(fails: vendor folder missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876ba78a18883308945392f6bd3f892