### PR TITLE
Implement user report modal and tests

### DIFF
--- a/database/factories/ReportFactory.php
+++ b/database/factories/ReportFactory.php
@@ -1,0 +1,23 @@
+<?php
+namespace Database\Factories;
+
+use App\Models\Report;
+use App\Models\User;
+use App\Models\Conversation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ReportFactory extends Factory
+{
+    protected $model = Report::class;
+
+    public function definition(): array
+    {
+        return [
+            'reporter_id' => User::factory(),
+            'reported_user_id' => User::factory(),
+            'conversation_id' => Conversation::factory(),
+            'reason' => $this->faker->sentence(),
+            'status' => 'pending',
+        ];
+    }
+}

--- a/resources/js/Components/Messages/ReportModal.jsx
+++ b/resources/js/Components/Messages/ReportModal.jsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import {
+  Button,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Textarea,
+  useDisclosure,
+} from '@chakra-ui/react';
+import axios from 'axios';
+import sweetAlert from '@/libs/sweetalert';
+
+export default function ReportModal({ reportedUserId, conversationId }) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [reason, setReason] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const submit = async () => {
+    if (!reason) return;
+    setLoading(true);
+    try {
+      await axios.post('/reports', {
+        reported_user_id: reportedUserId,
+        conversation_id: conversationId,
+        reason,
+      });
+      sweetAlert('Signalement envoyé', 'success');
+      setReason('');
+      onClose();
+    } catch (e) {
+      sweetAlert(e.response?.data?.message || 'Erreur lors du signalement');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Button size="xs" variant="outline" onClick={onOpen}>
+        Signaler
+      </Button>
+      <Modal isOpen={isOpen} onClose={onClose} isCentered>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Signaler cet utilisateur</ModalHeader>
+          <ModalBody>
+            <Textarea
+              placeholder="Raison du signalement"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+            />
+          </ModalBody>
+          <ModalFooter>
+            <Button mr={3} onClick={onClose} variant="ghost">
+              Annuler
+            </Button>
+            <Button colorScheme="brand" onClick={submit} isLoading={loading}>
+              Envoyer
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/resources/js/Pages/Messages/Index.jsx
+++ b/resources/js/Pages/Messages/Index.jsx
@@ -7,6 +7,7 @@ import VisitScheduler from '@/Components/Meeting/VisitScheduler';
 import VisitRequestCard from '@/Components/Meeting/VisitRequestCard';
 import VisitDoneModal from '@/Components/Meeting/VisitDoneModal';
 import VisitSellerConfirmModal from '@/Components/Meeting/VisitSellerConfirmModal';
+import ReportModal from '@/Components/Messages/ReportModal';
 import axios from 'axios';
 import sweetAlert from '@/libs/sweetalert';
 
@@ -20,14 +21,6 @@ export default function Index({ conversations: initial = {}, current }) {
   const [nextPage, setNextPage] = useState(initial.next_page_url);
   const [meetings, setMeetings] = useState([]);
   const [visit, setVisit] = useState(null);
-  const reportUser = async () => {
-    if (!partner) return;
-    await axios.post('/reports', {
-      reported_user_id: partner.id,
-      reason: 'inappropriate behavior',
-      conversation_id: active.id,
-    });
-  };
   const messagesEndRef = useRef(null);
 
   const errorShown = useRef(false);
@@ -184,7 +177,7 @@ export default function Index({ conversations: initial = {}, current }) {
                   <Text fontSize="sm" color="gray.600">
                     Dernière connexion : {partner.last_active_at ? new Date(partner.last_active_at).toLocaleString() : 'N/A'}
                   </Text>
-                  <Button size="xs" variant="outline" onClick={reportUser}>Signaler</Button>
+                  <ReportModal reportedUserId={partner.id} conversationId={active.id} />
                   {auth.user.id === active.seller_id && (
                     <VisitScheduler conversationId={active.id} onScheduled={() => loadConversation(active)} />
                   )}

--- a/tests/Feature/ReportTest.php
+++ b/tests/Feature/ReportTest.php
@@ -1,0 +1,63 @@
+<?php
+namespace Tests\Feature;
+
+use App\Models\Conversation;
+use App\Models\Report;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeConversation(): Conversation
+    {
+        return Conversation::factory()->create([
+            'seller_id' => User::factory()->create(['terms_accepted_at' => now()])->id,
+            'buyer_id' => User::factory()->create(['terms_accepted_at' => now()])->id,
+        ]);
+    }
+
+    public function test_user_can_create_report(): void
+    {
+        $conversation = $this->makeConversation();
+        $reporter = User::find($conversation->buyer_id);
+        $reported = User::find($conversation->seller_id);
+
+        $response = $this->actingAs($reporter)->post('/reports', [
+            'reported_user_id' => $reported->id,
+            'conversation_id' => $conversation->id,
+            'reason' => 'Spam',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('reports', [
+            'reporter_id' => $reporter->id,
+            'reported_user_id' => $reported->id,
+            'conversation_id' => $conversation->id,
+            'reason' => 'Spam',
+        ]);
+    }
+
+    public function test_duplicate_report_is_rejected(): void
+    {
+        $conversation = $this->makeConversation();
+        $reporter = User::find($conversation->buyer_id);
+        $reported = User::find($conversation->seller_id);
+
+        Report::factory()->create([
+            'reporter_id' => $reporter->id,
+            'reported_user_id' => $reported->id,
+            'conversation_id' => $conversation->id,
+        ]);
+
+        $response = $this->actingAs($reporter)->post('/reports', [
+            'reported_user_id' => $reported->id,
+            'conversation_id' => $conversation->id,
+            'reason' => 'Spam',
+        ]);
+
+        $response->assertStatus(409);
+    }
+}


### PR DESCRIPTION
## Summary
- enable reporting of users via new `ReportModal` component
- update messages page to use the modal
- add factory for reports and feature tests

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6876bcfc77648330bfa2d7e1c8206101