### PR TITLE
Add dark mode preference

### DIFF
--- a/app/Http/Controllers/User/ThemeController.php
+++ b/app/Http/Controllers/User/ThemeController.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Http\Controllers\User;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class ThemeController extends Controller
+{
+    public function update(Request $request)
+    {
+        $request->validate(['dark_mode' => 'boolean']);
+        $user = $request->user();
+        $user->dark_mode = $request->dark_mode;
+        $user->save();
+        return response()->json(['dark_mode' => $user->dark_mode]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -15,7 +15,8 @@ class User extends Authenticatable implements MustVerifyEmail
 
     protected $fillable = [
         'first_name', 'last_name', 'email', 'phone', 'password',
-        'certification_status', 'identity_document', 'certification_date', 'terms_accepted_at'
+        'certification_status', 'identity_document', 'certification_date', 'terms_accepted_at',
+        'dark_mode'
     ];
 
     protected $hidden = [
@@ -26,6 +27,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'email_verified_at' => 'datetime',
         'certification_date' => 'datetime',
         'terms_accepted_at' => 'datetime',
+        'dark_mode' => 'boolean',
     ];
 
     protected $appends = ['last_active_at'];

--- a/database/migrations/2025_07_15_210000_add_dark_mode_to_users_table.php
+++ b/database/migrations/2025_07_15_210000_add_dark_mode_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('dark_mode')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('dark_mode');
+        });
+    }
+};

--- a/resources/js/Components/Account/DarkModeToggle.jsx
+++ b/resources/js/Components/Account/DarkModeToggle.jsx
@@ -1,0 +1,28 @@
+import { Switch, FormControl, FormLabel } from '@chakra-ui/react';
+import { useColorMode } from '@chakra-ui/react';
+import { useState } from 'react';
+import axios from 'axios';
+
+export default function DarkModeToggle({ initial }) {
+  const { colorMode, toggleColorMode } = useColorMode();
+  const [checked, setChecked] = useState(initial === 'dark');
+
+  const handleChange = async () => {
+    const newMode = checked ? 'light' : 'dark';
+    toggleColorMode();
+    setChecked(!checked);
+    try {
+      await axios.post('/account/theme', { dark_mode: newMode === 'dark' });
+      localStorage.setItem('chakra-ui-color-mode', newMode);
+    } catch (e) {}
+  };
+
+  return (
+    <FormControl display="flex" alignItems="center">
+      <FormLabel htmlFor="dark-mode" mb="0">
+        Mode sombre
+      </FormLabel>
+      <Switch id="dark-mode" isChecked={checked} onChange={handleChange} />
+    </FormControl>
+  );
+}

--- a/resources/js/Components/Layout/Navbar.jsx
+++ b/resources/js/Components/Layout/Navbar.jsx
@@ -18,6 +18,7 @@ import {
 import { HamburgerIcon } from "@chakra-ui/icons";
 import NotificationBell from "../UI/NotificationBell";
 import MessagesBell from "../UI/MessagesBell";
+import DarkModeToggle from "../UI/DarkModeToggleButton";
 import { Link, usePage } from "@inertiajs/react";
 import { route } from "ziggy-js";
 
@@ -81,6 +82,7 @@ export default function Navbar() {
                 )}
                 <NotificationBell />
                 <MessagesBell />
+                <DarkModeToggle />
                 <Menu>
                     <MenuButton as={Button} variant="ghost" rightIcon={<HamburgerIcon />}>
                         <Avatar size="sm" name={auth.user.first_name} />

--- a/resources/js/Components/UI/DarkModeToggleButton.jsx
+++ b/resources/js/Components/UI/DarkModeToggleButton.jsx
@@ -1,0 +1,25 @@
+import { IconButton, useColorMode } from '@chakra-ui/react';
+import { MoonIcon, SunIcon } from '@chakra-ui/icons';
+import axios from 'axios';
+
+export default function DarkModeToggleButton({ userPref }) {
+  const { colorMode, toggleColorMode } = useColorMode();
+
+  const handleClick = async () => {
+    const newMode = colorMode === 'light' ? 'dark' : 'light';
+    toggleColorMode();
+    try {
+      await axios.post('/account/theme', { dark_mode: newMode === 'dark' });
+      localStorage.setItem('chakra-ui-color-mode', newMode);
+    } catch (e) {}
+  };
+
+  return (
+    <IconButton
+      aria-label="Toggle dark mode"
+      icon={colorMode === 'light' ? <MoonIcon /> : <SunIcon />}
+      variant="ghost"
+      onClick={handleClick}
+    />
+  );
+}

--- a/resources/js/Pages/Account/Settings.jsx
+++ b/resources/js/Pages/Account/Settings.jsx
@@ -15,6 +15,8 @@ import { InfoOutlineIcon, LockIcon, ArrowBackIcon } from '@chakra-ui/icons';
 import { Link, usePage } from '@inertiajs/react';
 import PersonalInfoForm from '@/Components/Account/PersonalInfoForm';
 import PasswordForm from '@/Components/Account/PasswordForm';
+import { MoonIcon } from '@chakra-ui/icons';
+import DarkModeToggle from '@/Components/Account/DarkModeToggle';
 
 export default function Settings({ user }) {
   const pageUser = user || usePage().props.user;
@@ -59,6 +61,9 @@ export default function Settings({ user }) {
           <Tab>
             <Icon as={LockIcon} mr={2} /> Mot de passe
           </Tab>
+          <Tab>
+            <Icon as={MoonIcon} mr={2} /> Apparence
+          </Tab>
         </TabList>
         <TabPanels ref={panelsRef} flex="1" pl={{ md: 6 }} mt={{ base: 4, md: 0 }}>
           <TabPanel px={0}>
@@ -66,6 +71,9 @@ export default function Settings({ user }) {
           </TabPanel>
           <TabPanel px={0}>
             <PasswordForm />
+          </TabPanel>
+          <TabPanel px={0}>
+            <DarkModeToggle initial={pageUser?.dark_mode ? 'dark' : 'light'} />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/resources/js/app.jsx
+++ b/resources/js/app.jsx
@@ -9,7 +9,7 @@ import 'slick-carousel/slick/slick-theme.css';
 import { createRoot } from 'react-dom/client';
 import { createInertiaApp } from '@inertiajs/react';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ChakraProvider } from '@chakra-ui/react';
+import { ChakraProvider, ColorModeScript } from '@chakra-ui/react';
 import { RecoilRoot } from 'recoil';
 import theme from './theme';
 import LayoutWrapper from './Components/Layout/LayoutWrapper';
@@ -26,6 +26,7 @@ createInertiaApp({
     createRoot(el).render(
       <RecoilRoot>
         <ChakraProvider theme={theme}>
+          <ColorModeScript initialColorMode={theme.config.initialColorMode} />
           <App {...props} />
         </ChakraProvider>
       </RecoilRoot>

--- a/resources/js/theme.js
+++ b/resources/js/theme.js
@@ -1,6 +1,10 @@
 import { extendTheme } from '@chakra-ui/react';
 
 const theme = extendTheme({
+  config: {
+    initialColorMode: 'light',
+    useSystemColorMode: false,
+  },
   fonts: {
     body: 'Inter, sans-serif',
     heading: 'Playfair Display, serif',
@@ -20,12 +24,12 @@ const theme = extendTheme({
     },
   },
   styles: {
-    global: {
+    global: (props) => ({
       body: {
-        bg: 'gray.100',
-        color: 'gray.800',
+        bg: props.colorMode === 'dark' ? 'gray.900' : 'gray.100',
+        color: props.colorMode === 'dark' ? 'gray.100' : 'gray.800',
       },
-    },
+    }),
   },
   components: {
     Button: {

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -17,6 +17,13 @@
         @vite(['resources/js/app.jsx', "resources/js/Pages/{$page['component']}.jsx"])
         @inertiaHead
         <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+        @php($colorMode = auth()->user()?->dark_mode ? 'dark' : 'light')
+        <script>
+            (function(){
+                var mode = localStorage.getItem('chakra-ui-color-mode') || '{{ $colorMode }}';
+                localStorage.setItem('chakra-ui-color-mode', mode);
+            })();
+        </script>
     </head>
     <body class="font-sans antialiased">
         @inertia

--- a/routes/web.php
+++ b/routes/web.php
@@ -167,6 +167,7 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/favorites', [PageController::class, 'favorites'])->name('favorites.index');
     Route::post('/listings/{listing}/favorite', [ListingController::class, 'toggle'])->name('favorites.toggle');
     Route::get('/account/settings', [PageController::class, 'accountSettings'])->name('account.settings');
+    Route::post('/account/theme', [\App\Http\Controllers\User\ThemeController::class, 'update'])->name('account.theme');
     Route::get('/account/clockings', [PageController::class, 'clockings'])->name('account.clockings');
     Route::get('/account/visits', [PageController::class, 'visits'])->name('account.visits');
     Route::get('/account/listings', [PageController::class, 'myListings'])->name('account.listings');


### PR DESCRIPTION
## Summary
- allow users to save their dark mode preference
- provide `DarkModeToggle` component and button in navbar
- integrate dark theme across Chakra UI
- set color mode from server on page load
- persist setting in database with new migration and controller

## Testing
- `php artisan test` *(fails: vendor folder missing)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876c0eaa5308330ad982fa1627c9bf4