### PR TITLE
Add listing documents step

### DIFF
--- a/app/Http/Controllers/Admin/ListingController.php
+++ b/app/Http/Controllers/Admin/ListingController.php
@@ -47,4 +47,13 @@ class ListingController extends Controller
 
         return response()->json(['message' => 'Status mis à jour']);
     }
+
+    public function documents(Listing $listing)
+    {
+        $listing->load('documents');
+        return Inertia::render('Admin/Listings/Documents', [
+            'listing' => $listing,
+            'documents' => $listing->documents,
+        ]);
+    }
 }

--- a/app/Http/Controllers/ListingController.php
+++ b/app/Http/Controllers/ListingController.php
@@ -103,9 +103,14 @@ class ListingController extends Controller
         $listing = Listing::create($data);
 
         if ($request->hasFile('documents')) {
-            foreach ($request->file('documents') as $file) {
+            foreach ($request->file('documents') as $type => $file) {
                 $path = $file->store('listing_documents', 'public');
-                $listing->documents()->create(['path' => $path, 'type' => 'document']);
+                $listing->documents()->create([
+                    'type' => $type,
+                    'name' => $file->getClientOriginalName(),
+                    'path' => $path,
+                    'is_required' => $type === 'dossier_diagnostic',
+                ]);
             }
         }
 
@@ -150,9 +155,14 @@ class ListingController extends Controller
         $listing->update($data);
 
         if ($request->hasFile('documents')) {
-            foreach ($request->file('documents') as $file) {
+            foreach ($request->file('documents') as $type => $file) {
                 $path = $file->store('listing_documents', 'public');
-                $listing->documents()->create(['path' => $path, 'type' => 'document']);
+                $listing->documents()->create([
+                    'type' => $type,
+                    'name' => $file->getClientOriginalName(),
+                    'path' => $path,
+                    'is_required' => $type === 'dossier_diagnostic',
+                ]);
             }
         }
 

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -1,0 +1,32 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+
+class Document extends Model
+{
+    protected $fillable = [
+        'listing_id',
+        'type',
+        'name',
+        'path',
+        'is_required',
+    ];
+
+    protected $casts = [
+        'is_required' => 'boolean',
+    ];
+
+    protected $appends = ['url'];
+
+    public function url(): Attribute
+    {
+        return Attribute::get(fn () => '/storage/' . ltrim($this->path, '/'));
+    }
+
+    public function listing()
+    {
+        return $this->belongsTo(Listing::class);
+    }
+}

--- a/app/Models/Listing.php
+++ b/app/Models/Listing.php
@@ -64,8 +64,9 @@ class Listing extends Model
         return $this->hasMany(DocumentToSign::class);
     }
 
-    public function documents() {
-        return $this->morphMany(File::class, 'fileable')->where('type', 'document');
+    public function documents()
+    {
+        return $this->hasMany(Document::class);
     }
 
     public function gallery() {

--- a/database/migrations/2025_07_30_000000_create_documents_table.php
+++ b/database/migrations/2025_07_30_000000_create_documents_table.php
@@ -1,0 +1,25 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('documents', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('listing_id')->constrained()->onDelete('cascade');
+            $table->string('type');
+            $table->string('name')->nullable();
+            $table->string('path');
+            $table->boolean('is_required')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('documents');
+    }
+};

--- a/resources/js/Pages/Admin/Listings/Documents.jsx
+++ b/resources/js/Pages/Admin/Listings/Documents.jsx
@@ -1,0 +1,22 @@
+import { Box, Heading, VStack, Flex, Link, Text, Button } from '@chakra-ui/react';
+import AdminLayout from '@/Components/Admin/AdminLayout';
+import { route } from 'ziggy-js';
+
+export default function Documents({ listing, documents = [] }) {
+  return (
+    <Box>
+      <Heading size="md" mb={4}>Documents pour: {listing.title}</Heading>
+      <VStack align="start" spacing={4}>
+        {documents.map(doc => (
+          <Flex key={doc.id} align="center" gap={2}>
+            <Link href={doc.url} isExternal>{doc.name || doc.path.split('/').pop()}</Link>
+          </Flex>
+        ))}
+        {documents.length === 0 && <Text>Aucun document fourni.</Text>}
+      </VStack>
+      <Button mt={4} as="a" href={route('admin.listings.index')}>Retour</Button>
+    </Box>
+  );
+}
+
+Documents.layout = page => <AdminLayout>{page}</AdminLayout>;

--- a/resources/js/Pages/Admin/Listings/Index.jsx
+++ b/resources/js/Pages/Admin/Listings/Index.jsx
@@ -41,6 +41,7 @@ export default function Index({ filters = {} }) {
             <Th>Propriétaire</Th>
             <Th>Status</Th>
             <Th>Actions</Th>
+            <Th>Documents</Th>
           </Tr>
         </Thead>
         <Tbody>
@@ -56,6 +57,11 @@ export default function Index({ filters = {} }) {
                   <option value="vendue">vendue</option>
                   <option value="archivée">archivée</option>
                 </Select>
+              </Td>
+              <Td>
+                <Button size="xs" as="a" href={route('admin.listings.documents', l.id)}>
+                  Voir
+                </Button>
               </Td>
             </Tr>
           ))}

--- a/resources/js/Pages/Listing/Create.jsx
+++ b/resources/js/Pages/Listing/Create.jsx
@@ -36,13 +36,24 @@ export default function Create({ categories: initialCategories = [] }) {
   const [step, setStep] = useState(1);
   const [previews, setPreviews] = useState([]);
   const [photos, setPhotos] = useState([]);
+  const [documents, setDocuments] = useState({});
   const [categories, setCategories] = useState(initialCategories);
   const stepsData = [
     { title: 'Informations', description: 'Titre et description' },
     { title: 'Détails', description: 'Caractéristiques du bien' },
     { title: 'Adresse', description: 'Localisation du bien' },
-    { title: 'Médias', description: 'Photos et documents' },
+    { title: 'Médias', description: 'Photos' },
+    { title: 'Documents', description: 'Pièces obligatoires' },
   ];
+
+  const documentFields = {
+    dossier_diagnostic: 'Dossier technique de diagnostic (obligatoire)',
+    taxe_fonciere: "Copie de l'avis de taxe foncière",
+    titre_propriete: 'Titre de propriété',
+    reglement_copropriete: 'Règlement de copropriété',
+    reglement_servitude: 'Règlement de servitude',
+    autres: 'Autres documents utiles',
+  };
 
   useEffect(() => {
     if (initialCategories.length === 0) {
@@ -72,12 +83,12 @@ export default function Create({ categories: initialCategories = [] }) {
     latitude: '',
     longitude: '',
     gallery: [],
-    documents: null,
+    documents: {},
   });
 
   useErrorAlert(errors);
 
-  const next = () => setStep((s) => Math.min(s + 1, 4));
+  const next = () => setStep((s) => Math.min(s + 1, 5));
   const back = () => setStep((s) => Math.max(s - 1, 1));
 
   const handleAddressSelect = ({ city, postal_code, lat, lng }) => {
@@ -109,8 +120,11 @@ export default function Create({ categories: initialCategories = [] }) {
     setPreviews(newFiles.map((f) => URL.createObjectURL(f)));
   };
 
-  const handleDocumentsChange = (e) => {
-    setData('documents', e.target.files);
+
+  const handleSingleDocumentChange = (key, file) => {
+    const newDocs = { ...documents, [key]: file };
+    setDocuments(newDocs);
+    setData('documents', newDocs);
   };
 
   const submit = (e) => {
@@ -257,7 +271,7 @@ export default function Create({ categories: initialCategories = [] }) {
         <Image src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/photo.svg" boxSize="60px" mx="auto" mb={4} alt="media" />
         <Alert status="info" rounded="md" mb={4}>
           <AlertIcon />
-          <Text fontSize="sm">Ajoutez des photos attractives (JPG/PNG, 4 Mo max). Vous pouvez joindre des documents au format PDF ou image.</Text>
+          <Text fontSize="sm">Ajoutez des photos attractives (JPG/PNG, 4 Mo max).</Text>
         </Alert>
         <VStack spacing={4} align="stretch">
           <FormControl isInvalid={errors.gallery}>
@@ -288,19 +302,43 @@ export default function Create({ categories: initialCategories = [] }) {
               ))}
             </SimpleGrid>
           )}
-          <FormControl isInvalid={errors.documents}>
-            <FormLabel>Documents</FormLabel>
-            <Input type="file" multiple onChange={handleDocumentsChange} />
-            <FormErrorMessage>{errors.documents}</FormErrorMessage>
-          </FormControl>
+        </VStack>
+        </>
+      )}
+
+      {step === 5 && (
+        <>
+        <Image src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/folder.svg" boxSize="60px" mx="auto" mb={4} alt="documents" />
+        <Alert status="info" rounded="md" mb={4}>
+          <AlertIcon />
+          <Text fontSize="sm">Téléchargez les documents nécessaires à la vente (PDF ou image).</Text>
+        </Alert>
+        <VStack spacing={4} align="stretch">
+          {Object.entries(documentFields).map(([key, label]) => (
+            <Flex key={key} direction={{ base: 'column', md: 'row' }} gap={2} align="center">
+              <FormLabel m={0} w={{ base: '100%', md: '40%' }}>{label}</FormLabel>
+              <Flex gap={2} w={{ base: '100%', md: '60%' }} direction={{ base: 'column', md: 'row' }}>
+                <Button leftIcon={<span>📎</span>} color="white" bg="#f74200" _hover={{ bg: '#d93c00' }} onClick={() => document.getElementById(key).click()} flex="1">
+                  Ajouter le document
+                </Button>
+                <Button leftIcon={<span>📷</span>} variant="outline" borderColor="#f74200" color="#f74200" onClick={() => document.getElementById(key).click()} flex="1">
+                  Scanner le document
+                </Button>
+                <Input type="file" id={key} accept="application/pdf,image/*" display="none" onChange={(e) => handleSingleDocumentChange(key, e.target.files[0])} />
+                {documents[key] && (
+                  <Text fontSize="sm">{documents[key].name}</Text>
+                )}
+              </Flex>
+            </Flex>
+          ))}
         </VStack>
         </>
       )}
 
       <Flex justify="space-between" mt={6}>
         {step > 1 && <Button onClick={back}>Précédent</Button>}
-        {step < 4 && <Button onClick={next}>Suivant</Button>}
-        {step === 4 && <Button type="submit" isLoading={processing}>Publier</Button>}
+        {step < 5 && <Button onClick={next}>Suivant</Button>}
+        {step === 5 && <Button type="submit" isLoading={processing}>Publier</Button>}
       </Flex>
     </Box>
   );

--- a/routes/web.php
+++ b/routes/web.php
@@ -80,6 +80,7 @@ Route::middleware(['auth', 'verified', 'terms', EnsureIsAdmin::class])
         Route::get('/listings', [AdminListingController::class, 'index'])->name('listings.index');
         Route::get('/listings/data', [AdminListingController::class, 'data'])->name('listings.data');
         Route::post('/listings/{listing}/status', [AdminListingController::class, 'setStatus'])->name('listings.status');
+        Route::get('/listings/{listing}/documents', [AdminListingController::class, 'documents'])->name('listings.documents');
 
         Route::get('/pages', [AdminPageController::class, 'index'])->name('pages.index');
         Route::get('/pages/{page}/edit', [AdminPageController::class, 'edit'])->name('pages.edit');


### PR DESCRIPTION
## Summary
- create `documents` table and Document model
- link Listing model to new documents
- upload documents with type information in ListingController
- allow editing/creating listing documents with new UI step
- let admin view listing documents

## Testing
- `composer install` *(fails: Required package not present)*

------
https://chatgpt.com/codex/tasks/task_e_6876c15295308330ac62ccf7a357d5eb