### PR TITLE
Fix buyer visit response refreshing

### DIFF
--- a/resources/js/Pages/Messages/Index.jsx
+++ b/resources/js/Pages/Messages/Index.jsx
@@ -79,9 +79,30 @@ export default function Index({ conversations: initial = {}, current }) {
     }
   };
 
+  const refreshDetails = async () => {
+    if (!active) return;
+    try {
+      const res = await axios.get(`/conversations/${active.id}`);
+      setMeetings(res.data.meetings || []);
+      setVisit(res.data.visit || null);
+    } catch (e) {
+      // ignore refresh errors silently
+    }
+  };
+
   const respondMeeting = async (id, status) => {
-    await axios.post(`/meetings/${id}/status`, { status });
-    setMeetings(ms => ms.map(m => m.id === id ? { ...m, status } : m));
+    try {
+      await axios.post(`/meetings/${id}/status`, { status });
+      sweetAlert(
+        status === 'accepted' ? 'Visite acceptée' : 'Visite refusée',
+        'success'
+      );
+      await refreshDetails();
+    } catch (e) {
+      sweetAlert(
+        e.response?.data?.message || "Erreur lors de la mise à jour de la visite"
+      );
+    }
   };
 
 


### PR DESCRIPTION
## Summary
- refresh conversation data after accepting or declining a visit
- show toast on visit response for immediate feedback

## Testing
- `composer install` *(fails: lock file inconsistent)*
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876c8ab4d34833082d9fe6a4b078229