### PR TITLE
Improve notification dropdown grouping

### DIFF
--- a/resources/js/Components/UI/NotificationBell.jsx
+++ b/resources/js/Components/UI/NotificationBell.jsx
@@ -13,7 +13,7 @@ import {
 } from '@chakra-ui/react';
 import { BellIcon } from '@chakra-ui/icons';
 import { Link, usePage } from '@inertiajs/react';
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useMemo } from 'react';
 import axios from 'axios';
 
 export default function NotificationBell() {
@@ -54,9 +54,10 @@ export default function NotificationBell() {
 
   const getInfo = (n) => {
     const name = `${n.sender.first_name} ${n.sender.last_name}`;
+    const countText = n.unread_count > 1 ? ` (${n.unread_count} non lus)` : '';
     if (n.type.includes('NewMessageNotification')) {
       return {
-        text: `${name} vous a envoyé un message`,
+        text: `${name} vous a envoyé un message${countText}`,
         href: `/messages?conversation=${n.data.conversation_id}`,
       };
     }
@@ -65,18 +66,35 @@ export default function NotificationBell() {
         n.data.type === 'visit'
           ? `${name} vous a demandé une visite`
           : `${name} vous propose un rendez-vous`;
-      return { text: base, href: `/messages?conversation=${n.data.conversation_id}` };
+      return { text: `${base}${countText}`, href: `/messages?conversation=${n.data.conversation_id}` };
     }
     if (n.type.includes('ListingFavoritedNotification')) {
-      return { text: `${name} a ajouté votre annonce à ses favoris`, href: `/listings/${n.data.listing_id}` };
+      return { text: `${name} a ajouté votre annonce à ses favoris${countText}`, href: `/listings/${n.data.listing_id}` };
     }
-    return { text: n.data.content || 'Notification', href: '#' };
+    return { text: (n.data.content || 'Notification') + countText, href: '#' };
   };
 
   const unreadCount =
     (Array.isArray(notifications)
       ? notifications.filter((n) => !n.read_at).length
       : 0) || unreadNotifications;
+
+  const groupedNotifications = useMemo(() => {
+    const groups = {};
+    notifications.forEach((n) => {
+      const key = n.data.conversation_id ?? n.data.listing_id ?? n.id;
+      const existing = groups[key];
+      if (!existing || new Date(n.created_at) > new Date(existing.created_at)) {
+        groups[key] = { ...n, unread_count: existing ? existing.unread_count : 0 };
+      }
+      if (!n.read_at) {
+        groups[key].unread_count = (groups[key].unread_count || 0) + 1;
+      }
+    });
+    return Object.values(groups).sort(
+      (a, b) => new Date(b.created_at) - new Date(a.created_at)
+    );
+  }, [notifications]);
 
   return (
     <Menu>
@@ -87,11 +105,11 @@ export default function NotificationBell() {
           </Badge>
         )}
       </MenuButton>
-      <MenuList w={{ base: '100%', sm: '300px' }}>
-        {notifications.length === 0 ? (
+      <MenuList w={{ base: '100%', sm: '300px' }} maxH="60vh" overflowY="auto">
+        {groupedNotifications.length === 0 ? (
           <MenuItem>Aucune notification</MenuItem>
         ) : (
-          notifications.map((n) => {
+          groupedNotifications.map((n) => {
             const { text, href } = getInfo(n);
             return (
               <MenuItem


### PR DESCRIPTION
## Summary
- aggregate notifications by conversation or topic
- display unread counts for grouped notifications
- set a max height on the dropdown so it scrolls when needed

## Testing
- `composer install --no-interaction --no-scripts` *(fails: Required package not in lock file)*
- `php artisan test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876cee4755083309eac0aa2422f0852