### PR TITLE
Add saved search alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Ce projet utilise **Laravel 12** avec **React** et Inertia pour construire une p
 > **Note :** L'application est uniquement orientée vers la **vente** de biens immobiliers. Aucune fonctionnalité de prêt ou de financement n'est prévue.
 
 Un système de recommandations propose désormais automatiquement des annonces en fonction des recherches sauvegardées et des favoris des utilisateurs.
+Les filtres de recherche peuvent être enregistrés pour recevoir des alertes par e‑mail et via le site dès qu'une nouvelle annonce correspond.
 
 ## Installation
 

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -137,6 +137,15 @@ class PageController extends Controller
         ]);
     }
 
+    public function savedSearches()
+    {
+        $searches = auth()->user()->savedSearches()->get();
+
+        return Inertia::render('Listing/SavedSearches', [
+            'searches' => $searches,
+        ]);
+    }
+
     public function messages(Request $request)
     {
         $conversations = Conversation::where('buyer_id', auth()->id())

--- a/app/Http/Controllers/SavedSearchController.php
+++ b/app/Http/Controllers/SavedSearchController.php
@@ -26,6 +26,21 @@ class SavedSearchController extends Controller
         return $search;
     }
 
+    public function update(Request $request, SavedSearch $search)
+    {
+        if ($search->user_id !== Auth::id()) {
+            abort(403);
+        }
+
+        $data = $request->validate([
+            'name' => 'nullable|string',
+            'notify' => 'boolean',
+        ]);
+
+        $search->update($data);
+        return $search;
+    }
+
     public function destroy(SavedSearch $search)
     {
         if ($search->user_id !== Auth::id()) {

--- a/resources/js/Components/Listing/FilterSidebar.jsx
+++ b/resources/js/Components/Listing/FilterSidebar.jsx
@@ -16,6 +16,8 @@ import {
   Select
 } from '@chakra-ui/react';
 import { FaMinus, FaPlus } from 'react-icons/fa';
+import axios from 'axios';
+import sweetAlert from '@/libs/sweetalert';
 
 export default function FilterSidebar({ searchParams, setSearchParams, onSearch }) {
   const [categories, setCategories] = useState([]);
@@ -46,6 +48,17 @@ export default function FilterSidebar({ searchParams, setSearchParams, onSearch 
 
   const decrement = field => {
     setSearchParams(prev => ({ ...prev, [field]: Math.max((prev[field] || 0) - 1, 0) }));
+  };
+
+  const saveSearch = async () => {
+    try {
+      await axios.post('/saved-searches', {
+        params: searchParams,
+      });
+      sweetAlert('Recherche sauvegardée', 'success');
+    } catch (e) {
+      sweetAlert("Erreur lors de l'enregistrement");
+    }
   };
 
   return (
@@ -176,6 +189,7 @@ export default function FilterSidebar({ searchParams, setSearchParams, onSearch 
         </Checkbox>
       </VStack>
 
+      <Button variant="outline" onClick={saveSearch}>Sauvegarder</Button>
       <Button colorScheme="brand" onClick={onSearch}>Rechercher</Button>
     </VStack>
   );

--- a/resources/js/Pages/Listing/SavedSearches.jsx
+++ b/resources/js/Pages/Listing/SavedSearches.jsx
@@ -1,0 +1,76 @@
+import { Box, Heading, Table, Thead, Tbody, Tr, Th, Td, Button, Switch, Text } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import sweetAlert from '@/libs/sweetalert';
+import { Link } from '@inertiajs/react';
+
+export default function SavedSearches({ searches: initial = [] }) {
+  const [searches, setSearches] = useState(initial);
+
+  useEffect(() => {
+    if (initial.length === 0) {
+      axios.get('/saved-searches').then(r => setSearches(r.data));
+    }
+  }, []);
+
+  const toggleNotify = async (search) => {
+    try {
+      const { data } = await axios.patch(`/saved-searches/${search.id}`, { notify: !search.notify });
+      setSearches(ss => ss.map(s => s.id === search.id ? data : s));
+    } catch (e) {
+      sweetAlert("Impossible de mettre à jour");
+    }
+  };
+
+  const remove = async (id) => {
+    if (!confirm('Supprimer cette recherche ?')) return;
+    try {
+      await axios.delete(`/saved-searches/${id}`);
+      setSearches(ss => ss.filter(s => s.id !== id));
+      sweetAlert('Recherche supprimée', 'success');
+    } catch (e) {
+      sweetAlert("Erreur lors de la suppression");
+    }
+  };
+
+  const searchLink = (params) => {
+    const query = new URLSearchParams(params).toString();
+    return `/listings/search?${query}`;
+  };
+
+  return (
+    <Box>
+      <Heading size="lg" mb={6}>Mes recherches sauvegardées</Heading>
+      {searches.length === 0 ? (
+        <Text>Aucune recherche enregistrée.</Text>
+      ) : (
+        <Table variant="simple">
+          <Thead>
+            <Tr>
+              <Th>Nom</Th>
+              <Th>Notifications</Th>
+              <Th>Actions</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {searches.map(s => (
+              <Tr key={s.id}>
+                <Td>
+                  <Button as={Link} href={searchLink(s.params)} variant="link">
+                    {s.name || 'Recherche du ' + new Date(s.created_at).toLocaleDateString()}
+                  </Button>
+                </Td>
+                <Td>
+                  <Switch isChecked={s.notify} onChange={() => toggleNotify(s)} />
+                </Td>
+                <Td>
+                  <Button size="xs" colorScheme="red" onClick={() => remove(s.id)}>Supprimer</Button>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      )}
+    </Box>
+  );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -172,9 +172,11 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/account/clockings', [PageController::class, 'clockings'])->name('account.clockings');
     Route::get('/account/visits', [PageController::class, 'visits'])->name('account.visits');
     Route::get('/account/listings', [PageController::class, 'myListings'])->name('account.listings');
+    Route::get('/account/searches', [PageController::class, 'savedSearches'])->name('account.searches');
 
     Route::get('/saved-searches', [SavedSearchController::class, 'index'])->name('searches.index');
     Route::post('/saved-searches', [SavedSearchController::class, 'store'])->name('searches.store');
+    Route::patch('/saved-searches/{search}', [SavedSearchController::class, 'update'])->name('searches.update');
     Route::delete('/saved-searches/{search}', [SavedSearchController::class, 'destroy'])->name('searches.destroy');
 
     Route::get('/recommendations', [ListingController::class, 'recommendations'])->name('listings.recommendations');

--- a/tests/Feature/SavedSearchTest.php
+++ b/tests/Feature/SavedSearchTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SavedSearchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_create_and_delete_saved_search(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/saved-searches', [
+            'params' => ['city' => 'Paris'],
+        ]);
+        $response->assertStatus(200);
+        $id = $response->json('id');
+        $this->assertDatabaseHas('saved_searches', ['id' => $id, 'user_id' => $user->id]);
+
+        $del = $this->actingAs($user)->delete("/saved-searches/$id");
+        $del->assertStatus(200);
+        $this->assertDatabaseMissing('saved_searches', ['id' => $id]);
+    }
+
+    public function test_user_can_toggle_notification(): void
+    {
+        $user = User::factory()->create();
+        $search = $user->savedSearches()->create(['params' => ['city' => 'Lyon']]);
+
+        $res = $this->actingAs($user)->patch("/saved-searches/{$search->id}", [
+            'notify' => false,
+        ]);
+        $res->assertStatus(200);
+        $this->assertFalse($search->fresh()->notify);
+    }
+}


### PR DESCRIPTION
## Summary
- allow saving searches in filter sidebar
- create saved searches management page
- enable updating/deleting saved searches via API
- add routes and controller method
- mention alerts in README
- test saved search creation and update

## Testing
- `php artisan test` *(fails: require vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_6876cf2558748330badb5f8852a02ff5