### PR TITLE
Add fan count and anonymous favorite notifications

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -10,14 +10,21 @@ class NotificationController extends Controller
     public function index()
     {
         $notifications = Auth::user()->notifications()->latest()->get()->map(function ($notification) {
-            $sender = User::withBasicInfo()->find($notification->data['sender_id']);
+            $data = $notification->data;
+            $sender = null;
+
+            if (!str_contains($notification->type, 'ListingFavoritedNotification')) {
+                $sender = User::withBasicInfo()->find($data['sender_id']);
+            } else {
+                unset($data['sender_id']);
+            }
 
             return [
                 'id' => $notification->id,
                 'type' => $notification->type,
                 'read_at' => $notification->read_at,
                 'created_at' => $notification->created_at,
-                'data' => $notification->data,
+                'data' => $data,
                 'sender' => $sender,
             ];
         });

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -128,7 +128,7 @@ class PageController extends Controller
     {
         $listings = Listing::where('user_id', auth()->id())
             ->with('category')
-            ->withCount('conversations')
+            ->withCount(['conversations', 'favoritedBy as favorites_count'])
             ->latest()
             ->get();
 

--- a/resources/js/Components/UI/NotificationBell.jsx
+++ b/resources/js/Components/UI/NotificationBell.jsx
@@ -53,7 +53,7 @@ export default function NotificationBell() {
   };
 
   const getInfo = (n) => {
-    const name = `${n.sender.first_name} ${n.sender.last_name}`;
+    const name = n.sender ? `${n.sender.first_name} ${n.sender.last_name}` : '';
     if (n.type.includes('NewMessageNotification')) {
       return {
         text: `${name} vous a envoyé un message`,
@@ -68,7 +68,7 @@ export default function NotificationBell() {
       return { text: base, href: `/messages?conversation=${n.data.conversation_id}` };
     }
     if (n.type.includes('ListingFavoritedNotification')) {
-      return { text: `${name} a ajouté votre annonce à ses favoris`, href: `/listings/${n.data.listing_id}` };
+      return { text: `Votre annonce a été ajoutée aux favoris`, href: `/listings/${n.data.listing_id}`, hideSender: true };
     }
     return { text: n.data.content || 'Notification', href: '#' };
   };
@@ -92,7 +92,7 @@ export default function NotificationBell() {
           <MenuItem>Aucune notification</MenuItem>
         ) : (
           notifications.map((n) => {
-            const { text, href } = getInfo(n);
+            const { text, href, hideSender } = getInfo(n);
             return (
               <MenuItem
                 key={n.id}
@@ -102,7 +102,9 @@ export default function NotificationBell() {
                 href={href}
               >
                 <HStack align="start" spacing={3} w="100%">
-                  <Avatar size="sm" name={`${n.sender.first_name} ${n.sender.last_name}`} />
+                  {!hideSender && (
+                    <Avatar size="sm" name={`${n.sender.first_name} ${n.sender.last_name}`} />
+                  )}
                   <Box flex="1">
                     <Text fontSize="sm" mb={1}>{text}</Text>
                     {n.read_at ? (

--- a/resources/js/Pages/Home/Show.jsx
+++ b/resources/js/Pages/Home/Show.jsx
@@ -147,6 +147,9 @@ export default function Show({ listing, similar = [] }) {
                   <Text fontWeight="bold">{listing.user.first_name} {listing.user.last_name}</Text>
                   <Text fontSize="sm" color="gray.600">Membre depuis {new Date(listing.user.created_at).toLocaleDateString()}</Text>
                   <Text fontSize="sm" color="gray.600">Annonces vendues : {listing.user.sold_count}</Text>
+                  {isOwner && (
+                    <Text fontSize="sm" color="gray.600">Fans : {listing.favorites_count}</Text>
+                  )}
                 </Stack>
               </Flex>
             </>

--- a/resources/js/Pages/Listing/MyListings.jsx
+++ b/resources/js/Pages/Listing/MyListings.jsx
@@ -30,6 +30,7 @@ export default function MyListings({ listings: initial = [] }) {
               <Th>Titre</Th>
               <Th>Status</Th>
               <Th>Demandes</Th>
+              <Th>Fans</Th>
               <Th>Actions</Th>
             </Tr>
           </Thead>
@@ -39,6 +40,7 @@ export default function MyListings({ listings: initial = [] }) {
                 <Td>{l.title}</Td>
                 <Td>{l.status}</Td>
                 <Td>{l.conversations_count}</Td>
+                <Td>{l.favorites_count}</Td>
                 <Td>
                   <Button as={Link} href={`/listings/${l.id}/edit`} size="xs" mr={2}>Modifier</Button>
                   <Button size="xs" colorScheme="red" variant="outline" onClick={() => remove(l.id)}>


### PR DESCRIPTION
## Summary
- anonymize sender for favorite notifications
- count `favorites_count` on listings page
- show fans count in the My Listings table
- display fans count for listing owners
- hide sender info in the notification bell

## Testing
- `composer test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876cf612b908330b056595b3bdf967b