### PR TITLE
Fix unfavorite button

### DIFF
--- a/app/Http/Controllers/FavoriteController.php
+++ b/app/Http/Controllers/FavoriteController.php
@@ -1,0 +1,47 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Favorite;
+use App\Models\Listing;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Notifications\ListingFavoritedNotification;
+
+class FavoriteController extends Controller
+{
+    public function store(Listing $listing)
+    {
+        $user = Auth::user();
+        $exists = Favorite::where('user_id', $user->id)
+            ->where('listing_id', $listing->id)
+            ->exists();
+
+        if (!$exists) {
+            Favorite::create([
+                'user_id' => $user->id,
+                'listing_id' => $listing->id,
+            ]);
+
+            if ($user->id !== $listing->user_id) {
+                $listing->user->notify(new ListingFavoritedNotification($listing, $user));
+            }
+        }
+
+        return response()->json(['status' => 'added']);
+    }
+
+    public function destroy(Listing $listing)
+    {
+        $user = Auth::user();
+
+        $favorite = Favorite::where('user_id', $user->id)
+            ->where('listing_id', $listing->id)
+            ->first();
+
+        if ($favorite) {
+            $favorite->delete();
+        }
+
+        return response()->json(['status' => 'removed']);
+    }
+}

--- a/resources/js/Components/Listing/ListingCard.jsx
+++ b/resources/js/Components/Listing/ListingCard.jsx
@@ -24,7 +24,12 @@ function FavoriteButton({ listingId, isFavorited, onToggle }) {
         const optimistic = !favorited;
         setFavorited(optimistic);
         try {
-            const response = await axios.post(`/listings/${listingId}/favorite`);
+            let response;
+            if (favorited) {
+                response = await axios.delete(`/favorites/${listingId}`);
+            } else {
+                response = await axios.post(`/favorites/${listingId}`);
+            }
             const newStatus = response.data.status;
             setFavorited(newStatus === 'added');
             if (onToggle) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,7 @@ use App\Http\Controllers\Admin\ClockingController as AdminClockingController;
 use App\Http\Controllers\Admin\VisitController as AdminVisitController;
 use App\Http\Controllers\Admin\DashboardController as AdminDashboardController;
 use App\Http\Controllers\FileController;
+use App\Http\Controllers\FavoriteController;
 use App\Http\Middleware\EnsureIsAdmin;
 use App\Http\Controllers\Admin\LoginController as AdminLoginController;
 use Illuminate\Http\Request;
@@ -166,7 +167,8 @@ Route::middleware(['auth', 'terms'])->group(function () {
 });
 Route::middleware(['auth'])->group(function () {
     Route::get('/favorites', [PageController::class, 'favorites'])->name('favorites.index');
-    Route::post('/listings/{listing}/favorite', [ListingController::class, 'toggle'])->name('favorites.toggle');
+    Route::post('/favorites/{listing}', [FavoriteController::class, 'store'])->name('favorites.store');
+    Route::delete('/favorites/{listing}', [FavoriteController::class, 'destroy'])->name('favorites.destroy');
     Route::get('/account/settings', [PageController::class, 'accountSettings'])->name('account.settings');
     Route::post('/account/theme', [\App\Http\Controllers\User\ThemeController::class, 'update'])->name('account.theme');
     Route::get('/account/clockings', [PageController::class, 'clockings'])->name('account.clockings');


### PR DESCRIPTION
## Summary
- add `FavoriteController` with RESTful add/remove actions
- update frontend favorite button to use POST/DELETE on `/favorites/{listing}`
- register new `favorites.store` and `favorites.destroy` routes

## Testing
- `composer install` *(fails: required packages not in lock file)*
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876cf7e6a308330a8473fef9710a34b