### PR TITLE
Fix undefined countText error in NotificationBell

### DIFF
--- a/resources/js/Components/UI/NotificationBell.jsx
+++ b/resources/js/Components/UI/NotificationBell.jsx
@@ -54,6 +54,7 @@ export default function NotificationBell() {
 
   const getInfo = (n) => {
     const name = n.sender ? `${n.sender.first_name} ${n.sender.last_name}` : '';
+    const countText = n.unread_count > 1 ? ` (${n.unread_count} non lus)` : '';
 
     if (n.type.includes('NewMessageNotification')) {
       return {


### PR DESCRIPTION
## Summary
- define `countText` within `NotificationBell` to display message counts

## Testing
- `composer test` *(fails: vendor directory missing)*
- `composer update` *(fails: network access blocked)*
- `npm run build` *(fails: vite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6876d24f21a48330987e10cf7952a319