### PR TITLE
Fix meeting status API path

### DIFF
--- a/resources/js/Pages/Messages/Index.jsx
+++ b/resources/js/Pages/Messages/Index.jsx
@@ -93,7 +93,7 @@ export default function Index({ conversations: initial = {}, current }) {
 
   const respondMeeting = async (id, status) => {
     try {
-      await axios.post(`/meetings/${id}/status`, { status });
+      await axios.post(`/api/meetings/${id}/status`, { status });
       sweetAlert(
         status === 'accepted' ? 'Visite acceptée' : 'Visite refusée',
         'success'


### PR DESCRIPTION
## Summary
- correct path when posting meeting status updates

## Testing
- `./vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6876e0a466c0833097ec8e208ec31d11