### PR TITLE
Use white logo in dark mode

### DIFF
--- a/resources/js/Components/Layout/Navbar.jsx
+++ b/resources/js/Components/Layout/Navbar.jsx
@@ -44,6 +44,8 @@ export default function Navbar() {
     const height = isScrolled ? "60px" : "80px";
     const transition = "all 0.3s ease";
 
+    const logoSrc = useColorModeValue('/logo.png', '/logo - blanc.png');
+
     return (
         <Flex
             as="nav"
@@ -59,7 +61,7 @@ export default function Navbar() {
         >
             <Link href="/">
                 <Image
-                    src="/logo.png"
+                    src={logoSrc}
                     alt="Logo PRIMO"
                     height={isScrolled ? "30px" : "40px"}
                     transition="height 0.3s ease"

--- a/resources/js/Pages/Auth/Login.jsx
+++ b/resources/js/Pages/Auth/Login.jsx
@@ -11,7 +11,8 @@ import {
     VStack,
     Divider,
     FormControl,
-    FormErrorMessage
+    FormErrorMessage,
+    useColorModeValue
 } from "@chakra-ui/react";
 import { Link } from '@inertiajs/react';
 
@@ -24,6 +25,8 @@ export default function Login() {
 
     useErrorAlert(errors);
 
+    const logoSrc = useColorModeValue('/logo.png', '/logo - blanc.png');
+
     const submit = (e) => {
         e.preventDefault();
         post('/login');
@@ -34,7 +37,7 @@ export default function Login() {
             <Flex flex={1} justify="center" align="center" bg="surface">
                 <Box w="full" maxW="md" p={8}>
                     <Flex justify="center" mb={6}>
-                        <Image src="/logo.png" alt="Logo" height="50px" />
+                        <Image src={logoSrc} alt="Logo" height="50px" />
                     </Flex>
                     <Heading size="lg" mb={6} textAlign="center">Bienvenue</Heading>
 

--- a/resources/js/Pages/Auth/Register.jsx
+++ b/resources/js/Pages/Auth/Register.jsx
@@ -12,7 +12,8 @@ import {
     FormErrorMessage,
     Flex,
     Image,
-    Text
+    Text,
+    useColorModeValue
 } from '@chakra-ui/react';
 
 export default function Register() {
@@ -27,6 +28,8 @@ export default function Register() {
 
     useErrorAlert(errors);
 
+    const logoSrc = useColorModeValue('/logo.png', '/logo - blanc.png');
+
     const submit = (e) => {
         e.preventDefault();
         post('/register');
@@ -36,7 +39,7 @@ export default function Register() {
         <Flex minH="100vh">
             {/* Left side form */}
             <Box flex="1" p={10} bg="surface" display="flex" flexDirection="column" justifyContent="center">
-                <Image src="/logo.png" alt="Logo" mb={6} w="150px" />
+                <Image src={logoSrc} alt="Logo" mb={6} w="150px" />
                 <Heading size="lg" mb={6}>Créer votre compte</Heading>
                 <form onSubmit={submit}>
                     <VStack spacing={4}>


### PR DESCRIPTION
## Summary
- swap logos based on Chakra color mode so dark mode uses `/logo - blanc.png`

## Testing
- `composer install --no-interaction` *(fails: Required package not present)*

------
https://chatgpt.com/codex/tasks/task_e_6876e34cf2a8833083217f72b245dfe8