### PR TITLE
Improve conversation UI

### DIFF
--- a/resources/js/Components/Chat/ChatMessage.jsx
+++ b/resources/js/Components/Chat/ChatMessage.jsx
@@ -1,0 +1,38 @@
+import { Box, Text, HStack, Avatar, Link, useColorModeValue } from '@chakra-ui/react';
+import { motion } from 'framer-motion';
+import { FaCheckDouble } from 'react-icons/fa';
+
+const MotionBox = motion(Box);
+
+export default function ChatMessage({ message, isMe }) {
+  return (
+    <HStack justify={isMe ? 'flex-end' : 'flex-start'} align="end" spacing={2}>
+      {!isMe && (
+        <Avatar size="sm" src={message.sender?.avatar} name={`${message.sender?.first_name || ''} ${message.sender?.last_name || ''}`} />
+      )}
+      <MotionBox
+        bg={isMe ? 'brand.500' : 'inputBg'}
+        color={isMe ? 'white' : 'inherit'}
+        borderRadius="lg"
+        px={3}
+        py={2}
+        maxW="75%"
+        shadow="md"
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.2 }}
+      >
+        <Text whiteSpace="pre-wrap">{message.content}</Text>
+        {message.file_url && (
+          <Link href={message.file_url} isExternal display="block" mt={1} fontSize="sm">
+            Fichier
+          </Link>
+        )}
+        <HStack fontSize="xs" color={useColorModeValue('gray.600', 'whiteAlpha.700')} justify="flex-end" mt={1}>
+          <Text>{new Date(message.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</Text>
+          {isMe && <FaCheckDouble color={message.is_read ? 'limegreen' : 'gray'} />}
+        </HStack>
+      </MotionBox>
+    </HStack>
+  );
+}

--- a/resources/js/Components/Chat/OfferCard.jsx
+++ b/resources/js/Components/Chat/OfferCard.jsx
@@ -1,0 +1,23 @@
+import { Box, Text, HStack, Button, VStack } from '@chakra-ui/react';
+
+export default function OfferCard({ offer, onAction }) {
+  return (
+    <Box bg="surfaceSubtle" p={4} borderRadius="md" shadow="sm">
+      <VStack align="stretch" spacing={2}>
+        <Text fontWeight="bold">Offre proposée</Text>
+        {offer.message && <Text>{offer.message}</Text>}
+        <Text fontWeight="bold">{Number(offer.price).toLocaleString()} €</Text>
+        {offer.status === 'pending' && (
+          <HStack pt={2} spacing={2} justify="flex-end">
+            <Button size="sm" colorScheme="green" onClick={() => onAction('accepted')}>Accepter</Button>
+            <Button size="sm" variant="outline" onClick={() => onAction('declined')}>Refuser</Button>
+            <Button size="sm" onClick={() => onAction('discuss')}>Discuter</Button>
+          </HStack>
+        )}
+        {offer.status === 'accepted' && (
+          <Text color="green.500" fontWeight="medium">Offre acceptée 🎉 — Prochaine étape : notaire</Text>
+        )}
+      </VStack>
+    </Box>
+  );
+}

--- a/resources/js/Components/Chat/PostVisitPrompt.jsx
+++ b/resources/js/Components/Chat/PostVisitPrompt.jsx
@@ -1,0 +1,46 @@
+import { Box, Text, HStack, IconButton, Button } from '@chakra-ui/react';
+import { FaStar } from 'react-icons/fa';
+import { useState } from 'react';
+import axios from 'axios';
+import sweetAlert from '@/libs/sweetalert';
+
+export default function PostVisitPrompt({ visit, onCompleted, onOffer }) {
+  const [rating, setRating] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  const submit = async () => {
+    if (!rating) return;
+    setLoading(true);
+    try {
+      await axios.post(`/visits/${visit.id}/feedback`, { rating });
+      sweetAlert('Merci pour votre avis!', 'success');
+      if (onCompleted) onCompleted();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box bg="surfaceSubtle" p={3} borderRadius="md" shadow="sm">
+      <Text fontWeight="bold" mb={2}>Comment s\'est passée la visite&nbsp;?</Text>
+      <HStack mb={3} spacing={1}>
+        {[1,2,3,4,5].map(i => (
+          <IconButton
+            key={i}
+            icon={<FaStar />}
+            variant={i <= rating ? 'solid' : 'outline'}
+            colorScheme="yellow"
+            size="sm"
+            onClick={() => setRating(i)}
+            aria-label={`note ${i}`}
+          />
+        ))}
+        <Button size="sm" ml={2} onClick={submit} isLoading={loading}>
+          Envoyer
+        </Button>
+      </HStack>
+      <Text fontWeight="bold" mb={2}>Souhaitez-vous faire une offre&nbsp;?</Text>
+      <Button size="sm" colorScheme="brand" onClick={onOffer}>Faire une offre</Button>
+    </Box>
+  );
+}

--- a/resources/js/Components/Chat/VisitConfirmedCard.jsx
+++ b/resources/js/Components/Chat/VisitConfirmedCard.jsx
@@ -1,0 +1,20 @@
+import { Box, Text, Button, HStack, Icon } from '@chakra-ui/react';
+import { FaCalendarCheck } from 'react-icons/fa';
+
+export default function VisitConfirmedCard({ visit }) {
+  return (
+    <Box bg="surfaceSubtle" p={3} borderRadius="md" shadow="sm">
+      <HStack justify="space-between" mb={2}>
+        <HStack>
+          <Icon as={FaCalendarCheck} color="brand.500" />
+          <Text fontWeight="bold">Visite confirmée</Text>
+        </HStack>
+        <Button size="sm" variant="outline">Voir / Modifier</Button>
+      </HStack>
+      <Text fontSize="sm">{new Date(visit.visit_datetime).toLocaleString()}</Text>
+      {visit.listing?.address && (
+        <Text fontSize="sm">{visit.listing.address}</Text>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add chat message components with avatars and timestamps
- show visit confirmation card and post-visit prompts
- integrate new chat UI into messages page

## Testing
- `php artisan test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_687750a878708330afa3ebab729246ff