### PR TITLE
Add GET meeting status route

### DIFF
--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -97,4 +97,10 @@ class MeetingController extends Controller
 
         return response()->json($meeting);
     }
+
+    public function updateFromLink(Meeting $meeting, string $status)
+    {
+        request()->merge(['status' => $status]);
+        return $this->update(request(), $meeting);
+    }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -124,6 +124,9 @@ Route::middleware(['auth', 'verified', 'terms', 'certified'])->group(function ()
     Route::post('/conversations/{conversation}/messages', [MessageController::class, 'store'])->middleware(['participant', 'conversation.open']);
     Route::post('/conversations/{conversation}/meetings', [MeetingController::class, 'store'])->middleware(['participant', 'conversation.open']);
     Route::post('/meetings/{meeting}/status', [MeetingController::class, 'update'])->middleware(['participant', 'conversation.open']);
+    Route::get('/meetings/{meeting}/status/{status}', [MeetingController::class, 'updateFromLink'])
+        ->middleware(['participant', 'conversation.open'])
+        ->where('status', 'accepted|declined');
     Route::get('/visits', [VisitController::class, 'index']);
     Route::post('/visits/{visit}/done', [VisitController::class, 'markDone']);
     Route::post('/visits/{visit}/confirm', [VisitController::class, 'sellerConfirm']);

--- a/tests/Feature/MeetingStatusGetTest.php
+++ b/tests/Feature/MeetingStatusGetTest.php
@@ -1,0 +1,51 @@
+<?php
+namespace Tests\Feature;
+
+use App\Models\Conversation;
+use App\Models\Listing;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MeetingStatusGetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeConversation(): Conversation
+    {
+        $seller = User::factory()->create([
+            'certification_status' => 'certifié',
+            'terms_accepted_at' => now(),
+        ]);
+        $buyer = User::factory()->create([
+            'certification_status' => 'certifié',
+            'terms_accepted_at' => now(),
+        ]);
+        $listing = Listing::factory()->create(['user_id' => $seller->id]);
+
+        return Conversation::factory()->create([
+            'listing_id' => $listing->id,
+            'seller_id' => $seller->id,
+            'buyer_id' => $buyer->id,
+        ]);
+    }
+
+    public function test_buyer_can_accept_meeting_via_get_route(): void
+    {
+        $conversation = $this->makeConversation();
+        $meeting = $conversation->meetings()->create([
+            'scheduled_at' => now()->addDay(),
+            'type' => 'visit',
+            'status' => 'pending',
+        ]);
+        $buyer = User::find($conversation->buyer_id);
+
+        $response = $this->actingAs($buyer)->get("/meetings/{$meeting->id}/status/accepted");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('meetings', [
+            'id' => $meeting->id,
+            'status' => 'accepted',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add a route to allow GET requests to accept/refuse meetings via URL
- implement `updateFromLink` in `MeetingController`
- cover GET status change with a feature test

## Testing
- `composer test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878204362bc8330aaa16d288c0c90d4