### PR TITLE
Use POST route for meeting status

### DIFF
--- a/tests/Feature/MeetingStatusTest.php
+++ b/tests/Feature/MeetingStatusTest.php
@@ -1,0 +1,53 @@
+<?php
+namespace Tests\Feature;
+
+use App\Models\Conversation;
+use App\Models\Listing;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MeetingStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeConversation(): Conversation
+    {
+        $seller = User::factory()->create([
+            'certification_status' => 'certifié',
+            'terms_accepted_at' => now(),
+        ]);
+        $buyer = User::factory()->create([
+            'certification_status' => 'certifié',
+            'terms_accepted_at' => now(),
+        ]);
+        $listing = Listing::factory()->create(['user_id' => $seller->id]);
+
+        return Conversation::factory()->create([
+            'listing_id' => $listing->id,
+            'seller_id' => $seller->id,
+            'buyer_id' => $buyer->id,
+        ]);
+    }
+
+    public function test_buyer_can_accept_meeting_via_post_route(): void
+    {
+        $conversation = $this->makeConversation();
+        $meeting = $conversation->meetings()->create([
+            'scheduled_at' => now()->addDay(),
+            'type' => 'visit',
+            'status' => 'pending',
+        ]);
+        $buyer = User::find($conversation->buyer_id);
+
+        $response = $this->actingAs($buyer)->post("/meetings/{$meeting->id}/status", [
+            'status' => 'accepted',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('meetings', [
+            'id' => $meeting->id,
+            'status' => 'accepted',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- revert GET meeting status route
- replace GET status test with POST variant

## Testing
- `composer test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878204362bc8330aaa16d288c0c90d4