### PR TITLE
Add confirmation modals with toast for delete actions

### DIFF
--- a/resources/js/Components/UI/ConfirmDeleteButton.jsx
+++ b/resources/js/Components/UI/ConfirmDeleteButton.jsx
@@ -1,0 +1,51 @@
+import { useRef } from 'react';
+import {
+  Button,
+  useDisclosure,
+  AlertDialog,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogBody,
+  AlertDialogFooter,
+} from '@chakra-ui/react';
+
+export default function ConfirmDeleteButton({
+  onConfirm,
+  label = 'Supprimer',
+  message = 'Êtes-vous sûr de vouloir supprimer cet élément ?',
+  children,
+  ...props
+}) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef();
+
+  const handleConfirm = async () => {
+    await onConfirm();
+    onClose();
+  };
+
+  return (
+    <>
+      <Button colorScheme="red" {...props} onClick={onOpen}>
+        {children || label}
+      </Button>
+      <AlertDialog isOpen={isOpen} leastDestructiveRef={cancelRef} onClose={onClose} isCentered>
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader>Confirmation</AlertDialogHeader>
+            <AlertDialogBody>{message}</AlertDialogBody>
+            <AlertDialogFooter>
+              <Button ref={cancelRef} onClick={onClose}>
+                Annuler
+              </Button>
+              <Button colorScheme="red" onClick={handleConfirm} ml={3}>
+                Supprimer
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
+    </>
+  );
+}

--- a/resources/js/Pages/Home/Show.jsx
+++ b/resources/js/Pages/Home/Show.jsx
@@ -6,6 +6,8 @@ import axios from 'axios';
 import { router, usePage } from '@inertiajs/react';
 import { FaEdit, FaTrash, FaInfoCircle } from 'react-icons/fa';
 import { useState } from 'react';
+import ConfirmDeleteButton from '@/Components/UI/ConfirmDeleteButton';
+import sweetAlert from '@/libs/sweetalert';
 
 export default function Show({ listing, similar = [] }) {
   const { auth } = usePage().props;
@@ -79,8 +81,8 @@ export default function Show({ listing, similar = [] }) {
   };
 
   const destroy = async () => {
-    if (!confirm('Supprimer cette annonce ?')) return;
     await axios.delete(`/listings/${listing.id}`);
+    sweetAlert('Annonce supprimée', 'success');
     router.get('/');
   };
 
@@ -92,7 +94,15 @@ export default function Show({ listing, similar = [] }) {
           {isOwner && !editing && (
             <Flex justify="flex-end" mt={2} gap={2}>
               <IconButton size="sm" icon={<FaEdit />} onClick={() => setEditing(true)} aria-label="Edit" />
-              <IconButton size="sm" icon={<FaTrash />} onClick={destroy} aria-label="Delete" />
+              <ConfirmDeleteButton
+                size="sm"
+                variant="ghost"
+                onConfirm={destroy}
+                message="Supprimer cette annonce ?"
+                aria-label="Delete"
+              >
+                <FaTrash />
+              </ConfirmDeleteButton>
             </Flex>
           )}
 

--- a/resources/js/Pages/Listing/Edit.jsx
+++ b/resources/js/Pages/Listing/Edit.jsx
@@ -32,6 +32,8 @@ import {
 } from '@chakra-ui/react';
 import AddressSearch from '@/Components/Listing/AddressSearch';
 import CategoryGrid from '@/Components/Listing/CategoryGrid';
+import ConfirmDeleteButton from '@/Components/UI/ConfirmDeleteButton';
+import sweetAlert from '@/libs/sweetalert';
 
 export default function Edit({ listing, categories: initialCategories = [] }) {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -138,6 +140,7 @@ export default function Edit({ listing, categories: initialCategories = [] }) {
     try {
       await axios.delete(`/files/${id}`);
       setExistingPhotos(photos => photos.filter(p => p.id !== id));
+      sweetAlert('Photo supprimée', 'success');
     } catch (err) {
       console.error(err);
     }
@@ -147,6 +150,7 @@ export default function Edit({ listing, categories: initialCategories = [] }) {
     try {
       await axios.delete(`/files/${id}`);
       setExistingDocs(docs => docs.filter(d => d.id !== id));
+      sweetAlert('Document supprimé', 'success');
     } catch (err) {
       console.error(err);
     }
@@ -166,7 +170,10 @@ export default function Edit({ listing, categories: initialCategories = [] }) {
 
   const remove = () => {
     destroy(`/listings/${listing.id}`, {
-      onSuccess: () => onClose(),
+      onSuccess: () => {
+        sweetAlert('Annonce supprimée', 'success');
+        onClose();
+      },
     });
   };
 
@@ -266,7 +273,16 @@ export default function Edit({ listing, categories: initialCategories = [] }) {
             {existingPhotos.map(photo => (
               <Box key={photo.id} position="relative">
                 <Image src={photo.url} alt="photo" objectFit="cover" h="100px" rounded="md" w="100%" />
-                <Button size="xs" colorScheme="red" position="absolute" top="2px" right="2px" onClick={() => deletePhoto(photo.id)}>X</Button>
+                <ConfirmDeleteButton
+                  size="xs"
+                  position="absolute"
+                  top="2px"
+                  right="2px"
+                  onConfirm={() => deletePhoto(photo.id)}
+                  message="Supprimer cette photo ?"
+                >
+                  X
+                </ConfirmDeleteButton>
               </Box>
             ))}
           </SimpleGrid>
@@ -304,7 +320,13 @@ export default function Edit({ listing, categories: initialCategories = [] }) {
             {existingDocs.map(doc => (
               <Flex key={doc.id} align="center">
                 <Link href={doc.url} isExternal mr={2}>{doc.name || doc.path.split('/').pop()}</Link>
-                <Button size="xs" colorScheme="red" onClick={() => deleteDoc(doc.id)}>Supprimer</Button>
+                <ConfirmDeleteButton
+                  size="xs"
+                  onConfirm={() => deleteDoc(doc.id)}
+                  message="Supprimer ce document ?"
+                >
+                  Supprimer
+                </ConfirmDeleteButton>
               </Flex>
             ))}
           </VStack>

--- a/resources/js/Pages/Listing/MyListings.jsx
+++ b/resources/js/Pages/Listing/MyListings.jsx
@@ -3,12 +3,12 @@ import { Link } from '@inertiajs/react';
 import { useState } from 'react';
 import axios from 'axios';
 import sweetAlert from '@/libs/sweetalert';
+import ConfirmDeleteButton from '@/Components/UI/ConfirmDeleteButton';
 
 export default function MyListings({ listings: initial = [] }) {
   const [listings, setListings] = useState(initial);
 
   const remove = async (id) => {
-    if (!confirm('Supprimer cette annonce ?')) return;
     try {
       await axios.delete(`/listings/${id}`);
       setListings(ls => ls.filter(l => l.id !== id));
@@ -43,9 +43,14 @@ export default function MyListings({ listings: initial = [] }) {
                 <Td>{l.favorites_count}</Td>
                 <Td>
                   <Button as={Link} href={`/listings/${l.id}/edit`} size="xs" mr={2}>Modifier</Button>
-                  <Button size="xs" colorScheme="red" variant="outline" onClick={() => remove(l.id)}>
+                  <ConfirmDeleteButton
+                    size="xs"
+                    variant="outline"
+                    onConfirm={() => remove(l.id)}
+                    message="Supprimer cette annonce ?"
+                  >
                     Supprimer
-                  </Button>
+                  </ConfirmDeleteButton>
                 </Td>
               </Tr>
             ))}

--- a/resources/js/Pages/Listing/SavedSearches.jsx
+++ b/resources/js/Pages/Listing/SavedSearches.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import axios from 'axios';
 import sweetAlert from '@/libs/sweetalert';
 import { Link } from '@inertiajs/react';
+import ConfirmDeleteButton from '@/Components/UI/ConfirmDeleteButton';
 
 export default function SavedSearches({ searches: initial = [] }) {
   const [searches, setSearches] = useState(initial);
@@ -23,7 +24,6 @@ export default function SavedSearches({ searches: initial = [] }) {
   };
 
   const remove = async (id) => {
-    if (!confirm('Supprimer cette recherche ?')) return;
     try {
       await axios.delete(`/saved-searches/${id}`);
       setSearches(ss => ss.filter(s => s.id !== id));
@@ -64,7 +64,13 @@ export default function SavedSearches({ searches: initial = [] }) {
                   <Switch isChecked={s.notify} onChange={() => toggleNotify(s)} />
                 </Td>
                 <Td>
-                  <Button size="xs" colorScheme="red" onClick={() => remove(s.id)}>Supprimer</Button>
+                  <ConfirmDeleteButton
+                    size="xs"
+                    onConfirm={() => remove(s.id)}
+                    message="Supprimer cette recherche ?"
+                  >
+                    Supprimer
+                  </ConfirmDeleteButton>
                 </Td>
               </Tr>
             ))}


### PR DESCRIPTION
## Summary
- create `ConfirmDeleteButton` reusable component
- use it for deleting listings, saved searches, photos and documents
- show toast after deletion

## Testing
- `composer test` *(fails: failed to open vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_6878231ab2908330b977301319c482b9