### PR TITLE
Implement transaction rating system

### DIFF
--- a/app/Http/Controllers/RatingController.php
+++ b/app/Http/Controllers/RatingController.php
@@ -1,0 +1,73 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Listing;
+use App\Models\Offer;
+use App\Models\TransactionRating;
+use App\Enums\ListingStatus;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class RatingController extends Controller
+{
+    public function store(Request $request, Listing $listing)
+    {
+        if ($listing->status !== ListingStatus::Sold) {
+            return response()->json(['message' => 'La transaction n\'est pas terminée'], 400);
+        }
+
+        $offer = Offer::where('listing_id', $listing->id)->where('status', 'accepted')->first();
+        if (! $offer) {
+            return response()->json(['message' => 'Aucune offre acceptée'], 404);
+        }
+
+        $data = $request->validate([
+            'communication' => 'required|integer|min:1|max:5',
+            'punctuality' => 'required|integer|min:1|max:5',
+            'professionalism' => 'required|integer|min:1|max:5',
+            'comment' => 'nullable|string',
+        ]);
+
+        $user = Auth::user();
+        if ($user->id === $listing->user_id) {
+            $ratedId = $offer->user_id;
+        } elseif ($user->id === $offer->user_id) {
+            $ratedId = $listing->user_id;
+        } else {
+            abort(403);
+        }
+
+        $rating = TransactionRating::updateOrCreate(
+            ['listing_id' => $listing->id, 'rater_id' => $user->id],
+            $data + [
+                'offer_id' => $offer->id,
+                'rated_id' => $ratedId,
+            ]
+        );
+
+        return response()->json($rating->fresh());
+    }
+
+    public function show(Listing $listing)
+    {
+        $offer = Offer::where('listing_id', $listing->id)->where('status', 'accepted')->first();
+        if (! $offer) {
+            return response()->json(['message' => 'Aucune offre acceptée'], 404);
+        }
+
+        $user = Auth::user();
+        if (! in_array($user->id, [$listing->user_id, $offer->user_id])) {
+            abort(403);
+        }
+
+        $my = TransactionRating::where('listing_id', $listing->id)->where('rater_id', $user->id)->first();
+        $other = TransactionRating::where('listing_id', $listing->id)
+            ->where('rater_id', $user->id === $listing->user_id ? $offer->user_id : $listing->user_id)
+            ->first();
+
+        return response()->json([
+            'my_rating' => $my,
+            'partner_rating' => $my && $other ? $other : null,
+        ]);
+    }
+}

--- a/app/Models/TransactionRating.php
+++ b/app/Models/TransactionRating.php
@@ -1,0 +1,46 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+
+class TransactionRating extends Model
+{
+    protected $fillable = [
+        'listing_id',
+        'offer_id',
+        'rater_id',
+        'rated_id',
+        'communication',
+        'punctuality',
+        'professionalism',
+        'comment',
+    ];
+
+    protected $appends = ['average'];
+
+    public function listing()
+    {
+        return $this->belongsTo(Listing::class);
+    }
+
+    public function offer()
+    {
+        return $this->belongsTo(Offer::class);
+    }
+
+    public function rater()
+    {
+        return $this->belongsTo(User::class, 'rater_id');
+    }
+
+    public function rated()
+    {
+        return $this->belongsTo(User::class, 'rated_id');
+    }
+
+    public function average(): Attribute
+    {
+        return Attribute::get(fn () => round(($this->communication + $this->punctuality + $this->professionalism) / 3, 1));
+    }
+}

--- a/database/migrations/2025_08_01_000003_create_transaction_ratings_table.php
+++ b/database/migrations/2025_08_01_000003_create_transaction_ratings_table.php
@@ -1,0 +1,28 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('transaction_ratings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('listing_id')->constrained()->onDelete('cascade');
+            $table->foreignId('offer_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('rater_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('rated_id')->constrained('users')->onDelete('cascade');
+            $table->unsignedTinyInteger('communication');
+            $table->unsignedTinyInteger('punctuality');
+            $table->unsignedTinyInteger('professionalism');
+            $table->text('comment')->nullable();
+            $table->timestamps();
+            $table->unique(['listing_id','rater_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('transaction_ratings');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,6 +30,7 @@ use App\Http\Controllers\FileController;
 use App\Http\Controllers\FavoriteController;
 use App\Http\Middleware\EnsureIsAdmin;
 use App\Http\Controllers\Admin\LoginController as AdminLoginController;
+use App\Http\Controllers\RatingController;
 use Illuminate\Http\Request;
 
 use Inertia\Inertia;
@@ -133,6 +134,8 @@ Route::middleware(['auth', 'verified', 'terms', 'certified'])->group(function ()
     Route::post('/visits/{visit}/feedback', [VisitController::class, 'feedback']);
     Route::post('/listings/{listing}/offers', [OfferController::class, 'store']);
     Route::patch('/offers/{offer}', [OfferController::class, 'update']);
+    Route::post('/listings/{listing}/ratings', [RatingController::class, 'store']);
+    Route::get('/listings/{listing}/ratings', [RatingController::class, 'show']);
     Route::post('/messages/{message}/read', [MessageController::class, 'markAsRead']);
 
     Route::get('/notifications', [NotificationController::class, 'index']);

--- a/tests/Unit/TransactionRatingTest.php
+++ b/tests/Unit/TransactionRatingTest.php
@@ -1,0 +1,19 @@
+<?php
+namespace Tests\Unit;
+
+use App\Models\TransactionRating;
+use PHPUnit\Framework\TestCase;
+
+class TransactionRatingTest extends TestCase
+{
+    public function test_average_attribute_is_calculated(): void
+    {
+        $rating = new TransactionRating([
+            'communication' => 4,
+            'punctuality' => 5,
+            'professionalism' => 3,
+        ]);
+
+        $this->assertSame(4.0, $rating->average);
+    }
+}


### PR DESCRIPTION
## Summary
- add TransactionRating model and migration
- support rating buyers and sellers after closing
- expose rating API routes
- provide unit test for rating average calculation

## Testing
- `composer install --no-interaction` *(fails: Required package not present in lock file)*
- `vendor/bin/phpunit --stop-on-failure` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687823f157608330a19cd337c86cb28d