### PR TITLE
Add conversation messages on visit response

### DIFF
--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -95,6 +95,20 @@ class MeetingController extends Controller
             }
         }
 
+        $msgContent = ($meeting->type === 'visit' ? 'Visite ' : 'Rendez-vous ') .
+            ($data['status'] === 'accepted' ? 'acceptée' : 'refusée');
+
+        $msg = Message::create([
+            'conversation_id' => $conversation->id,
+            'sender_id' => Auth::id(),
+            'content' => $msgContent,
+            'is_read' => false,
+        ]);
+
+        if ($recipient = User::find($conversation->seller_id)) {
+            $recipient->notify(new NewMessageNotification($msg));
+        }
+
         return response()->json($meeting);
     }
 

--- a/tests/Feature/MeetingStatusTest.php
+++ b/tests/Feature/MeetingStatusTest.php
@@ -49,6 +49,11 @@ class MeetingStatusTest extends TestCase
             'id' => $meeting->id,
             'status' => 'accepted',
         ]);
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversation->id,
+            'sender_id' => $buyer->id,
+            'content' => 'Visite acceptée',
+        ]);
     }
 
     public function test_buyer_can_decline_meeting_via_post_route(): void
@@ -69,6 +74,11 @@ class MeetingStatusTest extends TestCase
         $this->assertDatabaseHas('meetings', [
             'id' => $meeting->id,
             'status' => 'declined',
+        ]);
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversation->id,
+            'sender_id' => $buyer->id,
+            'content' => 'Visite refusée',
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- log a message in the conversation when a visit request is accepted or declined
- verify new messages in meeting status feature test

## Testing
- `composer test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_6879f17c11f88330884d4ae08f9bd7ec