### PR TITLE
Add admin notifications module

### DIFF
--- a/app/Http/Controllers/Admin/NotificationController.php
+++ b/app/Http/Controllers/Admin/NotificationController.php
@@ -5,10 +5,12 @@ use App\Http\Controllers\Controller;
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Support\Facades\Auth;
 use App\Models\User;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
 
 class NotificationController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
         $notifications = Auth::user()->notifications()->latest()->get()->map(function ($notification) {
             $user = User::withBasicInfo()->find($notification->data['user_id'] ?? null);
@@ -23,7 +25,13 @@ class NotificationController extends Controller
             ];
         });
 
-        return response()->json($notifications);
+        if ($request->wantsJson()) {
+            return response()->json($notifications);
+        }
+
+        return Inertia::render('Admin/Notifications/Index', [
+            'notifications' => $notifications,
+        ]);
     }
 
     public function markAsRead(DatabaseNotification $notification)

--- a/resources/js/Components/Admin/AdminLayout.jsx
+++ b/resources/js/Components/Admin/AdminLayout.jsx
@@ -15,7 +15,7 @@ import {
 } from '@chakra-ui/react';
 import { Link, usePage } from '@inertiajs/react';
 import AdminNotificationBell from './AdminNotificationBell';
-import { FaUsers, FaFileAlt, FaHome, FaFlag, FaClock, FaChartPie, FaBars, FaCalendarAlt } from 'react-icons/fa';
+import { FaUsers, FaFileAlt, FaHome, FaFlag, FaClock, FaChartPie, FaBars, FaCalendarAlt, FaBell } from 'react-icons/fa';
 
 export default function AdminLayout({ children }) {
   const { auth } = usePage().props;
@@ -63,6 +63,11 @@ export default function AdminLayout({ children }) {
             >
             <Icon as={FaFileAlt} />
             <Text>Documents</Text>
+          </ChakraLink>
+          <ChakraLink as={Link} href="/admin/notifications" display="flex" alignItems="center" gap={2}
+            >
+            <Icon as={FaBell} />
+            <Text>Notifications</Text>
           </ChakraLink>
         </Flex>
       </Box>

--- a/resources/js/Pages/Admin/Notifications/Index.jsx
+++ b/resources/js/Pages/Admin/Notifications/Index.jsx
@@ -1,0 +1,61 @@
+import { Box, Table, Thead, Tbody, Tr, Th, Td, Button } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { route } from 'ziggy-js';
+import AdminLayout from '@/Components/Admin/AdminLayout';
+
+export default function Index() {
+  const [notifications, setNotifications] = useState([]);
+
+  const load = async () => {
+    const { data } = await axios.get(route('admin.notifications.index'));
+    setNotifications(data);
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const markRead = async (id) => {
+    await axios.post(route('admin.notifications.read', id));
+    setNotifications(ns => ns.map(n => n.id === id ? { ...n, read_at: new Date().toISOString() } : n));
+  };
+
+  const markUnread = async (id) => {
+    await axios.post(route('admin.notifications.unread', id));
+    setNotifications(ns => ns.map(n => n.id === id ? { ...n, read_at: null } : n));
+  };
+
+  return (
+    <Box>
+      <Table variant="striped" colorScheme="gray" size="sm">
+        <Thead>
+          <Tr>
+            <Th>Utilisateur</Th>
+            <Th>Type</Th>
+            <Th>Date</Th>
+            <Th>Statut</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {notifications.map(n => (
+            <Tr key={n.id}>
+              <Td>{n.user ? `${n.user.first_name} ${n.user.last_name}` : '-'}</Td>
+              <Td>{n.type.split('\\').pop()}</Td>
+              <Td>{new Date(n.created_at).toLocaleString()}</Td>
+              <Td>{n.read_at ? 'Lu' : 'Non lu'}</Td>
+              <Td>
+                {n.read_at ? (
+                  <Button size="xs" onClick={() => markUnread(n.id)}>Marquer non lu</Button>
+                ) : (
+                  <Button size="xs" onClick={() => markRead(n.id)}>Marquer lu</Button>
+                )}
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+}
+
+Index.layout = (page) => <AdminLayout>{page}</AdminLayout>;


### PR DESCRIPTION
## Summary
- create admin notifications page
- allow notifications page or JSON from NotificationController
- add notifications link in admin navigation

## Testing
- `php artisan test` *(fails: vendor directory missing)*
- `npm install --ignore-scripts` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6879f1e499c883308fdd5dcfee81d212